### PR TITLE
Integrate GitHub Action to automatically create branches

### DIFF
--- a/.github/issue-branch.yml
+++ b/.github/issue-branch.yml
@@ -1,0 +1,12 @@
+mode: chatops
+silent: false
+branchName: full
+autoCloseIssue: true
+branches:
+  - label: question
+    skip: true
+openDraftPR: true
+copyIssueDescriptionToPR: true
+copyIssueLabelsToPR: true
+copyIssueAssigneeToPR: true
+copyIssueMilestoneToPR: true

--- a/.github/workflows/create-issue-branch.yml
+++ b/.github/workflows/create-issue-branch.yml
@@ -1,0 +1,16 @@
+name: Automatic Branch Creation
+
+on:
+  issue_comment:
+    types: [ created ]
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  create_issue_branch_job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Issue Branch
+        uses: robvanderleek/create-issue-branch@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I created an action to include the following App:
https://github.com/robvanderleek/create-issue-branch

This way, we can create a branch for a given issue by commenting `/cib` or `/create-issue-branch`.
I configured the app to:
 * not only create a branch but also a (draft) PR
 * copy description, labels, assign and milestone from the given issue to the newly created PR
 * auto close the original issue once the branch is merged