### PR TITLE
Makefile: add environment variable to specify Binary Ninja path

### DIFF
--- a/Makefile.venv
+++ b/Makefile.venv
@@ -11,6 +11,7 @@ $(VENV_PATH):
 	virtualenv -ppython$(PYTHON_VERSION) $(VENV_PATH)
 	. $(VENV_PATH)/bin/activate
 	pip install -r $(PREFIX)/requirements.txt
+	pip install -r $(PREFIX)/requirements-compiler-idioms.txt
 
 
 $(BINARY_NINJA_PATH)/python:

--- a/Makefile.venv
+++ b/Makefile.venv
@@ -9,24 +9,20 @@ venv: $(VENV_PATH) $(VENV_PATH)/lib/python$(PYTHON_VERSION)/site-packages/binary
 .ONESHELL: $(VENV_PATH)
 $(VENV_PATH):
 	virtualenv -ppython$(PYTHON_VERSION) $(VENV_PATH)
-	. $(VENV_PATH)/bin/activate
-	pip install -r $(PREFIX)/requirements.txt
-	pip install -r $(PREFIX)/requirements-compiler-idioms.txt
+	$(VENV_PATH)/bin/pip install -r $(PREFIX)/requirements.txt
+	$(VENV_PATH)/bin/pip install -r $(PREFIX)/requirements-compiler-idioms.txt
+
+
+$(VENV_PATH)/lib/python$(PYTHON_VERSION)/site-packages/binaryninja.pth: $(BINARY_NINJA_PATH)/python $(BINARY_NINJA_PATH)/scripts/install_api.py
+	$(VENV_PATH)/bin/python $$(readlink -f $(BINARY_NINJA_PATH)/scripts/install_api.py)
+	echo "$(BINARY_NINJA_PATH)/python" > $(VENV_PATH)/lib/python$(PYTHON_VERSION)/site-packages/binaryninja.pth
 
 
 $(BINARY_NINJA_PATH)/python:
-	@printf "\033[31m\033[1m\033[7mFailed to find Binary Ninja at '$(BINARY_NINJA_PATH)'.
-	Please set the BINARY_NINJA_PATH variable manually, e.g.
-	    make ... BINARY_NINJA_PATH=/your/path/to/binja
-	\033[0m\n"
+	@$(error Failed to find Binary Ninja at '$(BINARY_NINJA_PATH)'. \
+		Please set the BINARY_NINJA_PATH variable manually, e.g. \
+		    make ... BINARY_NINJA_PATH=/your/path/to/binja)
 
-
-$(VENV_PATH)/lib/python$(PYTHON_VERSION)/site-packages/binaryninja.pth: $(BINARY_NINJA_PATH)/python
-ifneq ($(wildcard $(BINARY_NINJA_PATH)/scripts/install_api.py),"")
-	. $(VENV_PATH)/bin/activate && \
-		$(VENV_PATH)/bin/python $$(readlink -f $(BINARY_NINJA_PATH)/scripts/install_api.py) && \
-		echo "$(BINARY_NINJA_PATH)/python" > $(VENV_PATH)/lib/python$(PYTHON_VERSION)/site-packages/binaryninja.pth
-else
+$(BINARY_NINJA_PATH)/scripts/install_api.py:
 	@$(error install_api.py not found. Please install the Binary Ninja API package manually using \
 		the install_api.py script from Binary Ninja.)
-endif

--- a/Makefile.venv
+++ b/Makefile.venv
@@ -1,4 +1,5 @@
 PYTHON_VERSION := 3.8
+BINARY_NINJA_PATH := /opt/binaryninja
 PREFIX := .
 
 .PHONY: venv
@@ -10,10 +11,16 @@ $(VENV_PATH):
 	virtualenv -ppython$(PYTHON_VERSION) $(VENV_PATH)
 	. $(VENV_PATH)/bin/activate
 	pip install -r $(PREFIX)/requirements.txt
-	pip install -r $(PREFIX)/requirements-compiler-idioms.txt
 
 
-$(VENV_PATH)/lib/python$(PYTHON_VERSION)/site-packages/binaryninja.pth:
+$(BINARY_NINJA_PATH)/python:
+	@printf "\033[31m\033[1m\033[7mFailed to find Binary Ninja at '$(BINARY_NINJA_PATH)'.
+	Please set the BINARY_NINJA_PATH variable manually, e.g.
+	    make ... BINARY_NINJA_PATH=/your/path/to/binja
+	\033[0m\n"
+
+
+$(VENV_PATH)/lib/python$(PYTHON_VERSION)/site-packages/binaryninja.pth: $(BINARY_NINJA_PATH)/python
 ifneq ($(wildcard $(PREFIX)/install_api.py),"")
 	. $(VENV_PATH)/bin/activate && \
 		$(VENV_PATH)/bin/python $$(readlink -f $(PREFIX)/install_api.py) && \

--- a/Makefile.venv
+++ b/Makefile.venv
@@ -22,9 +22,9 @@ $(BINARY_NINJA_PATH)/python:
 
 
 $(VENV_PATH)/lib/python$(PYTHON_VERSION)/site-packages/binaryninja.pth: $(BINARY_NINJA_PATH)/python
-ifneq ($(wildcard $(PREFIX)/install_api.py),"")
+ifneq ($(wildcard $(BINARY_NINJA_PATH)/scripts/install_api.py),"")
 	. $(VENV_PATH)/bin/activate && \
-		$(VENV_PATH)/bin/python $$(readlink -f $(PREFIX)/install_api.py) && \
+		$(VENV_PATH)/bin/python $$(readlink -f $(BINARY_NINJA_PATH)/scripts/install_api.py) && \
 		echo "/opt/binaryninja/python" > $(VENV_PATH)/lib/python$(PYTHON_VERSION)/site-packages/binaryninja.pth
 else
 	@$(error install_api.py not found. Please install the Binary Ninja API package manually using \

--- a/Makefile.venv
+++ b/Makefile.venv
@@ -9,8 +9,8 @@ venv: $(VENV_PATH) $(VENV_PATH)/lib/python$(PYTHON_VERSION)/site-packages/binary
 .ONESHELL: $(VENV_PATH)
 $(VENV_PATH):
 	virtualenv -ppython$(PYTHON_VERSION) $(VENV_PATH)
-	$(VENV_PATH)/bin/pip install -r $(PREFIX)/requirements.txt
-	$(VENV_PATH)/bin/pip install -r $(PREFIX)/requirements-compiler-idioms.txt
+	$(VENV_PATH)/bin/python -mpip install -r $(PREFIX)/requirements.txt
+	$(VENV_PATH)/bin/python -mpip install -r $(PREFIX)/requirements-compiler-idioms.txt
 
 
 $(VENV_PATH)/lib/python$(PYTHON_VERSION)/site-packages/binaryninja.pth: $(BINARY_NINJA_PATH)/python $(BINARY_NINJA_PATH)/scripts/install_api.py

--- a/Makefile.venv
+++ b/Makefile.venv
@@ -25,7 +25,7 @@ $(VENV_PATH)/lib/python$(PYTHON_VERSION)/site-packages/binaryninja.pth: $(BINARY
 ifneq ($(wildcard $(BINARY_NINJA_PATH)/scripts/install_api.py),"")
 	. $(VENV_PATH)/bin/activate && \
 		$(VENV_PATH)/bin/python $$(readlink -f $(BINARY_NINJA_PATH)/scripts/install_api.py) && \
-		echo "/opt/binaryninja/python" > $(VENV_PATH)/lib/python$(PYTHON_VERSION)/site-packages/binaryninja.pth
+		echo "$(BINARY_NINJA_PATH)/python" > $(VENV_PATH)/lib/python$(PYTHON_VERSION)/site-packages/binaryninja.pth
 else
 	@$(error install_api.py not found. Please install the Binary Ninja API package manually using \
 		the install_api.py script from Binary Ninja.)


### PR DESCRIPTION
Closes #65

I notice that `install_api.py` isn't bundled. Should we actually update to use `$BINARY_NINJA_PATH/scripts/install_api.py` instead of `./install_api.py` by default?