### PR TITLE
Exclude networkz version 2.8.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/fkie-cad/dewolf-logic.git
 black
 isort
-networkx
+networkx != 2.8.4
 pydot
 pygments
 pytest !=5.3.4


### PR DESCRIPTION
There is a bug in the current networkx version. So we want to exclude it.