### PR TITLE
118 gui decompilation gets started multiple times

### DIFF
--- a/decompiler/util/widget.py
+++ b/decompiler/util/widget.py
@@ -273,7 +273,7 @@ class DewolfWidget(QWidget, UIContextNotification):
         if self._current_function.name in self._cache.keys():
             self.update_code_view()
             return
-        self._cache[self._current_function.name] = "Add to queue..." # prevent multiple started workers for same function
+        self._cache[self._current_function.name] = "Add to queue..."  # prevent multiple started workers for same function
         self.start_worker(self._current_view, self._current_function)
 
     @Decorators.requires_function

--- a/decompiler/util/widget.py
+++ b/decompiler/util/widget.py
@@ -273,12 +273,12 @@ class DewolfWidget(QWidget, UIContextNotification):
         if self._current_function.name in self._cache.keys():
             self.update_code_view()
             return
+        self._cache[self._current_function.name] = "Add to queue..." # prevent multiple started workers for same function
         self.start_worker(self._current_view, self._current_function)
 
     @Decorators.requires_function
     def update_code_view(self):
         """Reload CodeDisplay content from cache"""
-        self.editor.set_font()  # responsive gui settings
         self.editor.setPlainText(self._cache.get(self._current_function.name, ""))
         self.highlighter.rehighlight()
 
@@ -297,7 +297,7 @@ class DewolfWidget(QWidget, UIContextNotification):
     def callback_worker_task_started(self, task_name: str):
         """Callback for decompilation task started"""
         logging.info(f"Started decompilation of {task_name}")
-        self._cache[task_name] = "In Queue"
+        self._cache[task_name] = "In queue"
         self.update_code_view()
 
     def callback_decompilation_finished(self):


### PR DESCRIPTION
Remove font update on every interaction. Only invoke one worker when using `follow` in the GUI