### PR TITLE
Redundant conditions

### DIFF
--- a/decompiler/pipeline/controlflowanalysis/restructuring_commons/ast_processor.py
+++ b/decompiler/pipeline/controlflowanalysis/restructuring_commons/ast_processor.py
@@ -191,7 +191,10 @@ class AcyclicProcessor(Processor):
         for cond_node in self.asforest.get_condition_nodes_post_order(root):
             cond_node.clean()
             if not cond_node.reaching_condition.is_true:
-                if cond_node.false_branch is None and (~cond_node.condition | cond_node.reaching_condition).remove_redundancy(self.asforest.condition_handler).is_true:
+                if (
+                    cond_node.false_branch is None
+                    and (~cond_node.condition | cond_node.reaching_condition).remove_redundancy(self.asforest.condition_handler).is_true
+                ):
                     cond_node.reaching_condition = LogicCondition.initialize_true(cond_node.reaching_condition.context)
 
     def _move_sequence_node_reaching_conditions_downward(self, root: AbstractSyntaxTreeNode):

--- a/decompiler/pipeline/controlflowanalysis/restructuring_commons/condition_aware_refinement_commons/initial_switch_node_constructer.py
+++ b/decompiler/pipeline/controlflowanalysis/restructuring_commons/condition_aware_refinement_commons/initial_switch_node_constructer.py
@@ -178,7 +178,7 @@ class InitialSwitchNodeConstructor(BaseClassConditionAwareRefinement):
                     switch_candidate_for[case_candidate.expression].cases.add(case_candidate)
                 else:
                     switch_candidate_for[case_candidate.expression] = SwitchNodeCandidate(
-                        case_candidate.expression.expression, {case_candidate}
+                        case_candidate.expression.expression, InsertionOrderedSet([case_candidate])
                     )
 
         self._remove_case_candidates_with_same_condition(switch_candidate_for.values())

--- a/decompiler/pipeline/controlflowanalysis/restructuring_commons/condition_aware_refinement_commons/initial_switch_node_constructer.py
+++ b/decompiler/pipeline/controlflowanalysis/restructuring_commons/condition_aware_refinement_commons/initial_switch_node_constructer.py
@@ -15,6 +15,7 @@ from decompiler.structures.ast.switch_node_handler import ExpressionUsages
 from decompiler.structures.ast.syntaxforest import AbstractSyntaxForest
 from decompiler.structures.logic.logic_condition import LogicCondition
 from decompiler.structures.pseudo import Break, Constant, Expression
+from decompiler.util.insertion_ordered_set import InsertionOrderedSet
 
 
 @dataclass
@@ -22,7 +23,7 @@ class SwitchNodeCandidate:
     """Class for possible Switch nodes."""
 
     expression: Expression
-    cases: Set[CaseNodeCandidate]
+    cases: InsertionOrderedSet[CaseNodeCandidate]
 
     def construct_switch_cases(self) -> Iterator[Tuple[CaseNode, AbstractSyntaxTreeNode]]:
         """Construct Switch-case for itself."""

--- a/decompiler/pipeline/controlflowanalysis/restructuring_commons/condition_aware_refinement_commons/missing_case_finder_sequence.py
+++ b/decompiler/pipeline/controlflowanalysis/restructuring_commons/condition_aware_refinement_commons/missing_case_finder_sequence.py
@@ -183,7 +183,7 @@ class MissingCaseFinderSequence(MissingCaseFinder):
             else:
                 case_constants_for_possible_case_node = set(self._get_case_constants_for_condition(possible_case.condition))
                 possible_case.update_reaching_condition_for_insertion()
-                sibling_reachability_graph.update_when_inserting_new_case_node(possible_case.node, switch_node)
+                sibling_reachability_graph.update_when_inserting_new_case_node(possible_case.get_head, switch_node)
                 self.asforest._code_node_reachability_graph.remove_reachability_between([possible_case.node, switch_node])
                 self._insert_case_node(possible_case.node, case_constants_for_possible_case_node, switch_node)
                 cases_of_switch_node.update(case_constants_for_possible_case_node)

--- a/decompiler/structures/ast/ast_nodes.py
+++ b/decompiler/structures/ast/ast_nodes.py
@@ -567,12 +567,7 @@ class ConditionNode(AbstractSyntaxTreeNode):
             self.condition &= self.reaching_condition
             self.condition.remove_redundancy(condition_handler)
             self.reaching_condition = LogicCondition.initialize_true(self.reaching_condition.context)
-            return
         super().simplify_reaching_condition(condition_handler)
-        # if self.true_branch.branch_condition.does_imply(self.reaching_condition):
-        #     pass
-        # elif self.false_branch.branch_condition.does_imply(self.reaching_condition):
-        #     pass
 
     def switch_branches(self):
         """Switch the true-branch and false-branch, this includes negating the condition."""

--- a/decompiler/structures/ast/ast_nodes.py
+++ b/decompiler/structures/ast/ast_nodes.py
@@ -567,7 +567,12 @@ class ConditionNode(AbstractSyntaxTreeNode):
             self.condition &= self.reaching_condition
             self.condition.remove_redundancy(condition_handler)
             self.reaching_condition = LogicCondition.initialize_true(self.reaching_condition.context)
+            return
         super().simplify_reaching_condition(condition_handler)
+        # if self.true_branch.branch_condition.does_imply(self.reaching_condition):
+        #     pass
+        # elif self.false_branch.branch_condition.does_imply(self.reaching_condition):
+        #     pass
 
     def switch_branches(self):
         """Switch the true-branch and false-branch, this includes negating the condition."""

--- a/tests/pipeline/controlflowanalysis/restructuring_commons/test_condition_aware_refinement.py
+++ b/tests/pipeline/controlflowanalysis/restructuring_commons/test_condition_aware_refinement.py
@@ -6,7 +6,7 @@ import pytest
 from decompiler.pipeline.controlflowanalysis.restructuring import PatternIndependentRestructuring
 from decompiler.structures.ast.ast_nodes import CaseNode, CodeNode, ConditionNode, SeqNode, SwitchNode, WhileLoopNode
 from decompiler.structures.graphs.cfg import BasicBlock, ControlFlowGraph, FalseCase, SwitchCase, TrueCase, UnconditionalEdge
-from decompiler.structures.pseudo.expressions import Constant, Expression, FunctionSymbol, ImportedFunctionSymbol, Variable
+from decompiler.structures.pseudo.expressions import Constant, Expression, FunctionSymbol, ImportedFunctionSymbol, Variable, StringSymbol
 from decompiler.structures.pseudo.instructions import Assignment, Branch, Break, Continue, IndirectBranch, Return
 from decompiler.structures.pseudo.operations import BinaryOperation, Call, Condition, ListOperation, OperationType, UnaryOperation
 from decompiler.structures.pseudo.typing import CustomType, Integer, Pointer, Type, UnknownType
@@ -5226,3 +5226,241 @@ def test_insert_after_existing_case(task):
             in {vertices[4].instructions[-1].condition, vertices[7].instructions[-1].condition}
         )
     assert isinstance(cn := cond.true_branch_child, CodeNode) and cn.instructions == vertices[3].instructions
+
+
+def test_nested_cases_unnecessary_condition_all_irrelevant(task):
+    """Test switch test 18_b"""
+    var_0_0 = Variable("var_0", Integer(32, True), None, True, Variable("var_10", Integer(32, True), 0, True, None))
+    var_0_2 = Variable("var_0", Integer(32, True), None, True, Variable("var_10", Integer(32, True), 2, True, None))
+    var_0_5 = Variable("var_0", Integer(32, True), None, True, Variable("var_10", Integer(32, True), 5, True, None))
+    task.graph.add_nodes_from(
+        vertices := [
+            BasicBlock(
+                0,
+                [
+                    Assignment(ListOperation([]), print_call("Enter week number(1-7): ", 1)),
+                    Assignment(
+                        ListOperation([]),
+                        scanf_call(
+                            UnaryOperation(OperationType.address, [var_0_0], Pointer(Integer(32, True), 32), None, False), 134524965, 2
+                        ),
+                    ),
+                    Branch(Condition(OperationType.equal, [var_0_2, Constant(500, Integer(32, True))], CustomType("bool", 1))),
+                ],
+            ),
+            BasicBlock(1, [Assignment(ListOperation([]), print_call("Friday", 3))]),
+            BasicBlock(2, [Branch(Condition(OperationType.greater, [var_0_2, Constant(500, Integer(32, True))], CustomType("bool", 1)))]),
+            BasicBlock(3, [Return(ListOperation([Constant(0, Integer(32, True))]))]),
+            BasicBlock(5, [Branch(Condition(OperationType.equal, [var_0_2, Constant(1, Integer(32, True))], CustomType("bool", 1)))]),
+            BasicBlock(6, [Assignment(ListOperation([]), print_call("Invalid input! Please enter week number between 1-7.", 11))]),
+            BasicBlock(
+                7,
+                [
+                    Assignment(ListOperation([]), print_call("Monday", 4)),
+                    Assignment(
+                        var_0_5, BinaryOperation(OperationType.plus, [var_0_2, Constant(500, Integer(32, True))], Integer(32, True))
+                    ),
+                ],
+            ),
+            BasicBlock(8, [Branch(Condition(OperationType.equal, [var_0_2, Constant(12, Integer(32, True))], CustomType("bool", 1)))]),
+            BasicBlock(9, [Assignment(ListOperation([]), print_call("Tuesday", 5))]),
+        ]
+    )
+    task.graph.add_edges_from(
+        [
+            TrueCase(vertices[0], vertices[1]),
+            FalseCase(vertices[0], vertices[2]),
+            UnconditionalEdge(vertices[1], vertices[3]),
+            TrueCase(vertices[2], vertices[5]),
+            FalseCase(vertices[2], vertices[4]),
+            TrueCase(vertices[4], vertices[6]),
+            FalseCase(vertices[4], vertices[7]),
+            UnconditionalEdge(vertices[5], vertices[3]),
+            UnconditionalEdge(vertices[6], vertices[8]),
+            TrueCase(vertices[7], vertices[8]),
+            FalseCase(vertices[7], vertices[5]),
+            UnconditionalEdge(vertices[8], vertices[3]),
+        ]
+    )
+
+    PatternIndependentRestructuring().run(task)
+
+    assert isinstance(seq_node := task._ast.root, SeqNode) and len(seq_node.children) == 3
+    assert isinstance(seq_node.children[0], CodeNode) and seq_node.children[0].instructions == vertices[0].instructions[:-1]
+    assert isinstance(switch := seq_node.children[1], SwitchNode)
+    assert isinstance(seq_node.children[2], CodeNode) and seq_node.children[2].instructions == vertices[3].instructions
+
+    # switch node:
+    assert switch.expression == var_0_2 and len(switch.children) == 4
+    assert isinstance(case1 := switch.cases[0], CaseNode) and case1.constant == Constant(1, Integer(32, True)) and case1.break_case is False
+    assert isinstance(case2 := switch.cases[1], CaseNode) and case2.constant == Constant(12, Integer(32, True)) and case2.break_case is True
+    assert (
+            isinstance(case3 := switch.cases[2], CaseNode) and case3.constant == Constant(500, Integer(32, True)) and case3.break_case is True
+    )
+    assert isinstance(default := switch.default, CaseNode)
+
+    # children of cases
+    assert isinstance(case1.child, CodeNode) and case1.child.instructions == vertices[6].instructions
+    assert isinstance(case2.child, CodeNode) and case2.child.instructions == vertices[8].instructions
+    assert isinstance(case3.child, CodeNode) and case3.child.instructions == vertices[1].instructions
+    assert isinstance(default.child, CodeNode) and default.child.instructions == vertices[5].instructions
+
+
+
+def test_nested_cases_unnecessary_condition_not_all_irrelevant(task):
+    """Test condition test 17"""
+    var_0 = Variable("var_0", Integer(32, True), None, True, Variable("var_10", Integer(32, True), 3, True, None))
+    arg1 = Variable("arg1", Integer(32, True), None, True, Variable("arg1", Integer(32, True), 0, True, None))
+    arg1_3 = Variable("arg1", Integer(32, True), None, True, Variable("eax", Integer(32, True), 3, True, None))
+    arg1_15 = Variable("arg1", Integer(32, True), None, True, Variable("var_24_1", Integer(32, True), 15, True, None))
+    arg1_8 = Variable("arg1", Integer(32, True), None, True, Variable("eax", Integer(32, True), 8, True, None))
+    var_1_15 = Variable("var_1", Integer(32, True), None, False, Variable("var_20_1", Integer(32, True), 15, False, None))
+    var_2_1 = Variable("var_2", Integer(32, True), None, False, Variable("edx", Integer(32, True), 1, False, None))
+    var_2_13 = Variable("var_2", Integer(32, True), None, False, Variable("edx", Integer(32, True), 13, False, None))
+    var_3_12 = Variable("var_3", Integer(32, True), None, False, Variable("eax_1", Integer(32, True), 12, False, None))
+
+    task.graph.add_nodes_from(
+        vertices := [
+            BasicBlock(
+                0,
+                [
+                    Assignment(ListOperation([]), print_call("Enter week number(1-7): ", 1)),
+                    Assignment(
+                        ListOperation([]),
+                        scanf_call(
+                            UnaryOperation(OperationType.address, [var_0], Pointer(Integer(32, True), 32), None, False), 0x134524965, 2
+                        ),
+                    ),
+                    Branch(Condition(OperationType.not_equal, [var_0, Constant(1, Integer(32, True))], CustomType("bool", 1))),
+                ],
+            ),
+            BasicBlock(1, [Branch(Condition(OperationType.not_equal, [var_0, Constant(2, Integer(32, True))], CustomType("bool", 1)))]),
+            BasicBlock(2, [Branch(Condition(OperationType.not_equal, [arg1, Constant(7, Integer(32, True))], CustomType("bool", 1)))]),
+            BasicBlock(3, [Assignment(arg1_3, var_0)]),
+            BasicBlock(4, [Assignment(ListOperation([]), print_call("Tuesday", 5))]),
+            BasicBlock(5, [Assignment(arg1_8, var_0)]),
+            BasicBlock(
+                6,
+                [
+                    Assignment(var_1_15, var_2_1),
+                    Assignment(arg1_15, Constant(1, Integer.int32_t())),
+                    Assignment(
+                        var_3_12, StringSymbol("The Input is 7 and you choose week number %d", 8949, Pointer(Integer.int32_t(), 32))
+                    ),
+                ],
+            ),
+            BasicBlock(7, [Branch(Condition(OperationType.not_equal, [var_0, Constant(3, Integer(32, True))], CustomType("bool", 1)))]),
+            BasicBlock(8, [Assignment(ListOperation([]), print_call("Wednesday", 7))]),
+            BasicBlock(9, [Branch(Condition(OperationType.not_equal, [var_0, Constant(4, Integer(32, True))], CustomType("bool", 1)))]),
+            BasicBlock(10, [Assignment(ListOperation([]), print_call("Thursday", 8))]),
+            BasicBlock(11, [Branch(Condition(OperationType.not_equal, [var_0, Constant(5, Integer(32, True))], CustomType("bool", 1)))]),
+            BasicBlock(12, [Assignment(ListOperation([]), print_call("Friday", 9))]),
+            BasicBlock(13, [Branch(Condition(OperationType.not_equal, [var_0, Constant(6, Integer(32, True))], CustomType("bool", 1)))]),
+            BasicBlock(14, [Assignment(ListOperation([]), print_call("Saturday", 10))]),
+            BasicBlock(15, [Branch(Condition(OperationType.not_equal, [var_0, Constant(7, Integer(32, True))], CustomType("bool", 1)))]),
+            BasicBlock(16, [Assignment(ListOperation([]), print_call("Sunday", 12))]),
+            BasicBlock(17, [Branch(Condition(OperationType.not_equal, [var_0, Constant(1, Integer(32, True))], CustomType("bool", 1)))]),
+            BasicBlock(
+                18,
+                [
+                    Assignment(var_1_15, var_2_13),
+                    Assignment(arg1_15, var_2_13),
+                    Assignment(var_3_12, StringSymbol("Monday", 8521, Pointer(Integer.int32_t(), 32))),
+                ],
+            ),
+            BasicBlock(19, [Assignment(ListOperation([]), print_call("common case", 13))]),
+            BasicBlock(20, [Return(ListOperation([Constant(0, Integer(32, True))]))]),
+        ]
+    )
+    task.graph.add_edges_from(
+        [
+            TrueCase(vertices[0], vertices[1]),
+            FalseCase(vertices[0], vertices[2]),
+            TrueCase(vertices[1], vertices[3]),
+            FalseCase(vertices[1], vertices[4]),
+            TrueCase(vertices[2], vertices[5]),
+            FalseCase(vertices[2], vertices[6]),
+            UnconditionalEdge(vertices[3], vertices[7]),
+            UnconditionalEdge(vertices[4], vertices[7]),
+            UnconditionalEdge(vertices[5], vertices[11]),
+            UnconditionalEdge(vertices[6], vertices[19]),
+            TrueCase(vertices[7], vertices[9]),
+            FalseCase(vertices[7], vertices[8]),
+            UnconditionalEdge(vertices[8], vertices[9]),
+            TrueCase(vertices[9], vertices[11]),
+            FalseCase(vertices[9], vertices[10]),
+            UnconditionalEdge(vertices[10], vertices[11]),
+            TrueCase(vertices[11], vertices[13]),
+            FalseCase(vertices[11], vertices[12]),
+            UnconditionalEdge(vertices[12], vertices[13]),
+            TrueCase(vertices[13], vertices[15]),
+            FalseCase(vertices[13], vertices[14]),
+            UnconditionalEdge(vertices[14], vertices[15]),
+            TrueCase(vertices[15], vertices[17]),
+            FalseCase(vertices[15], vertices[16]),
+            UnconditionalEdge(vertices[16], vertices[17]),
+            TrueCase(vertices[17], vertices[20]),
+            FalseCase(vertices[17], vertices[18]),
+            UnconditionalEdge(vertices[18], vertices[19]),
+            UnconditionalEdge(vertices[19], vertices[20]),
+        ]
+    )
+
+    PatternIndependentRestructuring().run(task)
+
+    assert isinstance(seq_node := task._ast.root, SeqNode) and len(seq_node.children) == 4
+    assert isinstance(seq_node.children[0], CodeNode) and seq_node.children[0].instructions == vertices[0].instructions[:-1]
+    assert isinstance(cond:= seq_node.children[1], ConditionNode)
+    assert isinstance(switch := seq_node.children[2], SwitchNode)
+    assert isinstance(seq_node.children[3], CodeNode) and seq_node.children[3].instructions == vertices[20].instructions
+
+    # condition node:
+    assert cond.condition.is_conjunction and {task._ast.condition_map[l] for l in cond.condition.operands} == {vertices[0].instructions[-1].condition, vertices[1].instructions[0].condition}
+    assert cond.false_branch is None and isinstance(cn := cond.true_branch_child, CodeNode) and cn.instructions == vertices[3].instructions
+
+    # switch node:
+    assert switch.expression == var_0 and len(switch.children) == 7
+    assert (
+            isinstance(case1 := switch.cases[0], CaseNode)
+            and case1.constant == Constant(1, Integer(32, signed=True))
+            and case1.break_case is True
+    )
+    assert (
+            isinstance(case2 := switch.cases[1], CaseNode)
+            and case2.constant == Constant(2, Integer(32, signed=True))
+            and case2.break_case is True
+    )
+    assert (
+            isinstance(case3 := switch.cases[2], CaseNode)
+            and case3.constant == Constant(3, Integer(32, signed=True))
+            and case3.break_case is True
+    )
+    assert (
+            isinstance(case4 := switch.cases[3], CaseNode)
+            and case4.constant == Constant(4, Integer(32, signed=True))
+            and case4.break_case is True
+    )
+    assert (
+            isinstance(case5 := switch.cases[4], CaseNode)
+            and case5.constant == Constant(5, Integer(32, signed=True))
+            and case5.break_case is True
+    )
+    assert (
+            isinstance(case6 := switch.cases[5], CaseNode)
+            and case6.constant == Constant(6, Integer(32, signed=True))
+            and case6.break_case is True
+    )
+    assert (
+            isinstance(case7 := switch.cases[6], CaseNode)
+            and case7.constant == Constant(7, Integer(32, signed=True))
+            and case7.break_case is True
+    )
+
+    # children of cases
+    assert isinstance(case1.child, SeqNode)
+    assert isinstance(case2.child, CodeNode) and case2.child.instructions == vertices[4].instructions
+    assert isinstance(case3.child, CodeNode) and case3.child.instructions == vertices[8].instructions
+    assert isinstance(case4.child, CodeNode) and case4.child.instructions == vertices[10].instructions
+    assert isinstance(case5.child, CodeNode) and case5.child.instructions == vertices[12].instructions
+    assert isinstance(case6.child, CodeNode) and case6.child.instructions == vertices[14].instructions
+    assert isinstance(case7.child, CodeNode) and case7.child.instructions == vertices[16].instructions

--- a/tests/pipeline/controlflowanalysis/restructuring_commons/test_condition_aware_refinement.py
+++ b/tests/pipeline/controlflowanalysis/restructuring_commons/test_condition_aware_refinement.py
@@ -6,7 +6,7 @@ import pytest
 from decompiler.pipeline.controlflowanalysis.restructuring import PatternIndependentRestructuring
 from decompiler.structures.ast.ast_nodes import CaseNode, CodeNode, ConditionNode, SeqNode, SwitchNode, WhileLoopNode
 from decompiler.structures.graphs.cfg import BasicBlock, ControlFlowGraph, FalseCase, SwitchCase, TrueCase, UnconditionalEdge
-from decompiler.structures.pseudo.expressions import Constant, Expression, FunctionSymbol, ImportedFunctionSymbol, Variable, StringSymbol
+from decompiler.structures.pseudo.expressions import Constant, Expression, FunctionSymbol, ImportedFunctionSymbol, StringSymbol, Variable
 from decompiler.structures.pseudo.instructions import Assignment, Branch, Break, Continue, IndirectBranch, Return
 from decompiler.structures.pseudo.operations import BinaryOperation, Call, Condition, ListOperation, OperationType, UnaryOperation
 from decompiler.structures.pseudo.typing import CustomType, Integer, Pointer, Type, UnknownType
@@ -5295,7 +5295,7 @@ def test_nested_cases_unnecessary_condition_all_irrelevant(task):
     assert isinstance(case1 := switch.cases[0], CaseNode) and case1.constant == Constant(1, Integer(32, True)) and case1.break_case is False
     assert isinstance(case2 := switch.cases[1], CaseNode) and case2.constant == Constant(12, Integer(32, True)) and case2.break_case is True
     assert (
-            isinstance(case3 := switch.cases[2], CaseNode) and case3.constant == Constant(500, Integer(32, True)) and case3.break_case is True
+        isinstance(case3 := switch.cases[2], CaseNode) and case3.constant == Constant(500, Integer(32, True)) and case3.break_case is True
     )
     assert isinstance(default := switch.default, CaseNode)
 
@@ -5304,7 +5304,6 @@ def test_nested_cases_unnecessary_condition_all_irrelevant(task):
     assert isinstance(case2.child, CodeNode) and case2.child.instructions == vertices[8].instructions
     assert isinstance(case3.child, CodeNode) and case3.child.instructions == vertices[1].instructions
     assert isinstance(default.child, CodeNode) and default.child.instructions == vertices[5].instructions
-
 
 
 def test_nested_cases_unnecessary_condition_not_all_irrelevant(task):
@@ -5410,50 +5409,53 @@ def test_nested_cases_unnecessary_condition_not_all_irrelevant(task):
 
     assert isinstance(seq_node := task._ast.root, SeqNode) and len(seq_node.children) == 4
     assert isinstance(seq_node.children[0], CodeNode) and seq_node.children[0].instructions == vertices[0].instructions[:-1]
-    assert isinstance(cond:= seq_node.children[1], ConditionNode)
+    assert isinstance(cond := seq_node.children[1], ConditionNode)
     assert isinstance(switch := seq_node.children[2], SwitchNode)
     assert isinstance(seq_node.children[3], CodeNode) and seq_node.children[3].instructions == vertices[20].instructions
 
     # condition node:
-    assert cond.condition.is_conjunction and {task._ast.condition_map[l] for l in cond.condition.operands} == {vertices[0].instructions[-1].condition, vertices[1].instructions[0].condition}
+    assert cond.condition.is_conjunction and {task._ast.condition_map[l] for l in cond.condition.operands} == {
+        vertices[0].instructions[-1].condition,
+        vertices[1].instructions[0].condition,
+    }
     assert cond.false_branch is None and isinstance(cn := cond.true_branch_child, CodeNode) and cn.instructions == vertices[3].instructions
 
     # switch node:
     assert switch.expression == var_0 and len(switch.children) == 7
     assert (
-            isinstance(case1 := switch.cases[0], CaseNode)
-            and case1.constant == Constant(1, Integer(32, signed=True))
-            and case1.break_case is True
+        isinstance(case1 := switch.cases[0], CaseNode)
+        and case1.constant == Constant(1, Integer(32, signed=True))
+        and case1.break_case is True
     )
     assert (
-            isinstance(case2 := switch.cases[1], CaseNode)
-            and case2.constant == Constant(2, Integer(32, signed=True))
-            and case2.break_case is True
+        isinstance(case2 := switch.cases[1], CaseNode)
+        and case2.constant == Constant(2, Integer(32, signed=True))
+        and case2.break_case is True
     )
     assert (
-            isinstance(case3 := switch.cases[2], CaseNode)
-            and case3.constant == Constant(3, Integer(32, signed=True))
-            and case3.break_case is True
+        isinstance(case3 := switch.cases[2], CaseNode)
+        and case3.constant == Constant(3, Integer(32, signed=True))
+        and case3.break_case is True
     )
     assert (
-            isinstance(case4 := switch.cases[3], CaseNode)
-            and case4.constant == Constant(4, Integer(32, signed=True))
-            and case4.break_case is True
+        isinstance(case4 := switch.cases[3], CaseNode)
+        and case4.constant == Constant(4, Integer(32, signed=True))
+        and case4.break_case is True
     )
     assert (
-            isinstance(case5 := switch.cases[4], CaseNode)
-            and case5.constant == Constant(5, Integer(32, signed=True))
-            and case5.break_case is True
+        isinstance(case5 := switch.cases[4], CaseNode)
+        and case5.constant == Constant(5, Integer(32, signed=True))
+        and case5.break_case is True
     )
     assert (
-            isinstance(case6 := switch.cases[5], CaseNode)
-            and case6.constant == Constant(6, Integer(32, signed=True))
-            and case6.break_case is True
+        isinstance(case6 := switch.cases[5], CaseNode)
+        and case6.constant == Constant(6, Integer(32, signed=True))
+        and case6.break_case is True
     )
     assert (
-            isinstance(case7 := switch.cases[6], CaseNode)
-            and case7.constant == Constant(7, Integer(32, signed=True))
-            and case7.break_case is True
+        isinstance(case7 := switch.cases[6], CaseNode)
+        and case7.constant == Constant(7, Integer(32, signed=True))
+        and case7.break_case is True
     )
 
     # children of cases


### PR DESCRIPTION
Handle redundant conditions for conditions-nodes in front of sequence nodes, as in the following example:
![z_ast](https://github.com/fkie-cad/dewolf/assets/7224664/3f804ddd-8e00-4119-b6ae-c09fdcdeb239)
Here the condition of node 4 is irrelevant for the condition of node 8