### PR TITLE
Change super type of typing/Float from typing/Integer to typing/Type

### DIFF
--- a/decompiler/backend/cexpressiongenerator.py
+++ b/decompiler/backend/cexpressiongenerator.py
@@ -289,7 +289,7 @@ class CExpressionGenerator(DataflowObjectVisitorInterface):
         """Return a string representation of a mem phi instruction. Only included for completeness."""
         return f"{instr}"
 
-    def _get_integer_literal_value(self, literal: expressions.Constant) -> Union[float, int]:
+    def _get_integer_literal_value(self, literal: expressions.Constant) -> int:
         """
         Return the right integer value for the given type, assuming that the
         re-compilation host has the same sizes as the decompilation host.

--- a/decompiler/backend/cexpressiongenerator.py
+++ b/decompiler/backend/cexpressiongenerator.py
@@ -4,7 +4,7 @@ from itertools import chain, repeat
 from typing import Union
 
 from decompiler.structures import pseudo as expressions
-from decompiler.structures.pseudo import Float, Integer, OperationType, Pointer, StringSymbol
+from decompiler.structures.pseudo import Float, Integer, OperationType, StringSymbol
 from decompiler.structures.pseudo import instructions as instructions
 from decompiler.structures.pseudo import operations as operations
 from decompiler.structures.visitors.interfaces import DataflowObjectVisitorInterface
@@ -158,7 +158,7 @@ class CExpressionGenerator(DataflowObjectVisitorInterface):
 
     def visit_constant(self, expr: expressions.Constant) -> str:
         """Return constant in a format that will be parsed correctly by a compiler."""
-        if isinstance(expr.type, Integer) and not isinstance(expr.type, (Float, Pointer)):
+        if isinstance(expr.type, Integer):
             value = self._get_integer_literal_value(expr)
             return self._format_integer_literal(expr.type, value)
         if isinstance(expr, StringSymbol):

--- a/decompiler/backend/codevisitor.py
+++ b/decompiler/backend/codevisitor.py
@@ -180,7 +180,7 @@ class CodeVisitor(ASTVisitorInterface, CExpressionGenerator):
             and isinstance(target_operand, expressions.Constant)
             and (
                 (isinstance(target_operand.type, Float) and self._use_increment_float)
-                or ((isinstance(target_operand.type, Integer) and not isinstance(target_operand.type, Float)) and self._use_increment_int)
+                or (isinstance(target_operand.type, Integer) and self._use_increment_int)
             )
             and (target_operand.value == 0x1 or target_operand.value == -0x1)
         )

--- a/decompiler/pipeline/controlflowanalysis/expression_simplification.py
+++ b/decompiler/pipeline/controlflowanalysis/expression_simplification.py
@@ -6,7 +6,7 @@ from decompiler.structures.ast.ast_nodes import CodeNode
 from decompiler.structures.pseudo.expressions import Constant, Expression
 from decompiler.structures.pseudo.instructions import Instruction
 from decompiler.structures.pseudo.operations import BinaryOperation, Operation, OperationType, UnaryOperation
-from decompiler.structures.pseudo.typing import Integer
+from decompiler.structures.pseudo.typing import Float, Integer
 from decompiler.task import DecompilerTask
 
 
@@ -128,13 +128,11 @@ class ExpressionSimplification(PipelineStage):
     @staticmethod
     def negate_expression(expression: Expression) -> Expression:
         """Negate the given expression and return it."""
-        if isinstance(expression, Constant) and expression.value == 0:
-            return expression
-        if isinstance(expression, UnaryOperation) and expression.operation == OperationType.negate:
-            return expression.operand
-        if isinstance(expression, Constant) and isinstance(expression.type, Integer) and expression.type.is_signed:
-            return Constant(-expression.value, expression.type)
-        return UnaryOperation(OperationType.negate, [expression])
+        match expression:
+            case Constant(value=0): return expression
+            case UnaryOperation(operation=OperationType.negate): return expression.operand
+            case Constant(type=Integer(is_signed=True) | Float()): return Constant(-expression.value, expression.type)
+            case _: return UnaryOperation(OperationType.negate, [expression])
 
     @staticmethod
     def get_other_operand(binary_operation: BinaryOperation, expression: Expression) -> Expression:

--- a/decompiler/pipeline/controlflowanalysis/variable_name_generation.py
+++ b/decompiler/pipeline/controlflowanalysis/variable_name_generation.py
@@ -145,7 +145,7 @@ class HungarianScheme(RenamingScheme):
             else:
                 return ""
         if isinstance(var_type, (Integer, Float)):
-            sign = "" if var_type.is_signed else "u"
+            sign = "u" if isinstance(var_type, Integer) and not var_type.is_signed else ""
             prefix = self.type_prefix[type(var_type)].get(var_type.size, "unk")
             return f"{sign}{prefix}"
         return ""

--- a/decompiler/pipeline/dataflowanalysis/type_propagation.py
+++ b/decompiler/pipeline/dataflowanalysis/type_propagation.py
@@ -11,7 +11,7 @@ from decompiler.pipeline.stage import PipelineStage
 from decompiler.structures.graphs.cfg import ControlFlowGraph
 from decompiler.structures.pseudo.expressions import Expression, Variable
 from decompiler.structures.pseudo.instructions import BaseAssignment, Instruction
-from decompiler.structures.pseudo.typing import CustomType, Float, Integer, Pointer, Type, UnknownType
+from decompiler.structures.pseudo.typing import CustomType, Integer, Pointer, Type, UnknownType
 from decompiler.task import DecompilerTask
 from networkx import DiGraph, Graph, connected_components
 
@@ -133,8 +133,8 @@ class TypePropagation(PipelineStage):
 
     @staticmethod
     def _is_non_primitive_type(type: Type) -> bool:
-        """Check if the given type is primitive, so ew can ignore it."""
-        if isinstance(type, Integer) and not isinstance(type, Float):
+        """Check if the given type is primitive, so we can ignore it."""
+        if isinstance(type, Integer):
             return False
         if isinstance(type, Pointer) and type.type == CustomType.void():
             return False

--- a/decompiler/structures/pseudo/typing.py
+++ b/decompiler/structures/pseudo/typing.py
@@ -131,14 +131,14 @@ class Integer(Type):
 
 
 @dataclass(frozen=True, order=True)
-class Float(Integer):
+class Float(Type):
     """Class representing the type of a floating point number as defined in IEEE 754."""
 
     SIZE_TYPES = {8: "quarter", 16: "half", 32: "float", 64: "double", 80: "long double", 128: "quadruple", 256: "octuple"}
 
-    def __init__(self, size: int, signed=True):
+    def __init__(self, size: int):
         """Create a new float type with the given size."""
-        super().__init__(size, signed)
+        super().__init__(size)
 
     @classmethod
     def float(cls) -> Float:


### PR DESCRIPTION
Currently, `typing/Float` extends `typing/Integer`. This makes it non trivial to check if a type is an integer.
eg: `isInstance(type, Integer) and not isInstance(type, Float)` or `type.__class__ == Integer.__class__`

This pull request is a quick fix which changes the super type of `Float` from `Integer` to `Type` and all affected code by this change.