### PR TITLE
Remove duplicated 'FunctionTypeDef' definition

### DIFF
--- a/decompiler/structures/pseudo/typing.py
+++ b/decompiler/structures/pseudo/typing.py
@@ -217,16 +217,6 @@ class FunctionTypeDef(Type):
         return f"{self.return_type}({', '.join(str(x) for x in self.parameters)})"
 
 
-@dataclass(frozen=True, order=True)
-class FunctionTypeDef(Type):
-    return_type: Type
-    parameters: Tuple[Parameter, ...]
-
-    def __str__(self) -> str:
-        """Return an anonymous string representation such as void*(int, int, char*)."""
-        return f"{self.return_type}({', '.join(str(x) for x in self.parameters)})"
-
-
 class TypeParser:
     """A type parser in charge of creating types."""
 


### PR DESCRIPTION
This pr removes the duplicated `FunctionTypeDef` class definition introduced with #253.