### PR TITLE
Add configuration option for allowing for-loops

### DIFF
--- a/decompiler/util/default.json
+++ b/decompiler/util/default.json
@@ -280,7 +280,7 @@
                 "default": true,
                 "type": "boolean",
                 "title": "Enable for-loop recovery",
-                "description": "If enabled, certain while-loops will be transformed to for-loops. If set to false, no for-loops will be emitted at all.",,
+                "description": "If enabled, certain while-loops will be transformed to for-loops. If set to false, no for-loops will be emitted at all.",
                 "is_hidden_from_gui": false,
                 "is_hidden_from_cli": false,
                 "argument_name": "--restructure-for-loops"

--- a/decompiler/util/default.json
+++ b/decompiler/util/default.json
@@ -276,6 +276,16 @@
                 "argument_name": "--return-complexity-threshold"
             },
             {
+                "dest": "readability-based-refinement.restructure_for_loops",
+                "default": true,
+                "type": "boolean",
+                "title": "Restructure for-loops at all",
+                "description": "Transform while-loops to for-loops. If set to false, no for-loop is restructured.",
+                "is_hidden_from_gui": false,
+                "is_hidden_from_cli": false,
+                "argument_name": "--restructure-for-loops"
+            },
+            {
                 "dest": "readability-based-refinement.keep_empty_for_loops",
                 "default": false,
                 "type": "boolean",

--- a/decompiler/util/default.json
+++ b/decompiler/util/default.json
@@ -279,8 +279,8 @@
                 "dest": "readability-based-refinement.restructure_for_loops",
                 "default": true,
                 "type": "boolean",
-                "title": "Restructure for-loops at all",
-                "description": "Transform while-loops to for-loops. If set to false, no for-loop is restructured.",
+                "title": "Enable for-loop recovery",
+                "description": "If enabled, certain while-loops will be transformed to for-loops. If set to false, no for-loops will be emitted at all.",,
                 "is_hidden_from_gui": false,
                 "is_hidden_from_cli": false,
                 "argument_name": "--restructure-for-loops"


### PR DESCRIPTION
For the ISR cooperation, we promised a config-option that turns the reconstruction of for-loops on and off.
This is now implemented. If the option is set to `true`, still all other configuration options have to hold in order to reconstruct a for-loop. If it is set to `false`, no for loop is restructured.

Question: This overwrites the option `force_for_loop`, i.e., if `restructure_for_loop` is set to `false` and `force_for_loop` to `true`, no for-loop is restructured. Do we want a warning in this scenario?