### PR TITLE
[Expression simplifcation] Improve error handling

### DIFF
--- a/decompiler/pipeline/controlflowanalysis/expression_simplification/rules/collapse_constants.py
+++ b/decompiler/pipeline/controlflowanalysis/expression_simplification/rules/collapse_constants.py
@@ -1,4 +1,9 @@
-from decompiler.pipeline.controlflowanalysis.expression_simplification.constant_folding import FOLDABLE_OPERATIONS, constant_fold
+from decompiler.pipeline.controlflowanalysis.expression_simplification.constant_folding import (
+    UnsupportedMismatchedSizes,
+    UnsupportedOperationType,
+    UnsupportedValueType,
+    constant_fold,
+)
 from decompiler.pipeline.controlflowanalysis.expression_simplification.rules.rule import SimplificationRule
 from decompiler.structures.pseudo import Constant, Expression, Operation
 
@@ -11,10 +16,10 @@ class CollapseConstants(SimplificationRule):
     def apply(self, operation: Operation) -> list[tuple[Expression, Expression]]:
         if not all(isinstance(o, Constant) for o in operation.operands):
             return []
-        if operation.operation not in FOLDABLE_OPERATIONS:
+
+        try:
+            folded_constant = constant_fold(operation.operation, operation.operands, operation.type)
+        except (UnsupportedOperationType, UnsupportedValueType, UnsupportedMismatchedSizes):
             return []
 
-        return [(
-            operation,
-            constant_fold(operation.operation, operation.operands)
-        )]
+        return [(operation, folded_constant)]

--- a/decompiler/pipeline/controlflowanalysis/expression_simplification/rules/collapse_constants.py
+++ b/decompiler/pipeline/controlflowanalysis/expression_simplification/rules/collapse_constants.py
@@ -14,6 +14,8 @@ class CollapseConstants(SimplificationRule):
     """
 
     def apply(self, operation: Operation) -> list[tuple[Expression, Expression]]:
+        if not operation.operands:
+            return []  # Is this even allowed?
         if not all(isinstance(o, Constant) for o in operation.operands):
             return []
 

--- a/decompiler/pipeline/controlflowanalysis/expression_simplification/rules/term_order.py
+++ b/decompiler/pipeline/controlflowanalysis/expression_simplification/rules/term_order.py
@@ -20,7 +20,7 @@ class TermOrder(SimplificationRule):
         if operation.operation not in COMMUTATIVE_OPERATIONS:
             return []
         if not isinstance(operation, BinaryOperation):
-            raise TypeError(f"Expected BinaryOperation, got {operation}")
+            raise TypeError(f"Expected BinaryOperation, got {type(operation)}")
 
         if isinstance(operation.left, Constant) and not isinstance(operation.right, Constant):
             return [(operation, BinaryOperation(operation.operation, [operation.right, operation.left], operation.type, operation.tags))]

--- a/decompiler/pipeline/controlflowanalysis/expression_simplification/rules/term_order.py
+++ b/decompiler/pipeline/controlflowanalysis/expression_simplification/rules/term_order.py
@@ -20,7 +20,7 @@ class TermOrder(SimplificationRule):
         if operation.operation not in COMMUTATIVE_OPERATIONS:
             return []
         if not isinstance(operation, BinaryOperation):
-            raise ValueError(f"Expected BinaryOperation, got {operation}")
+            raise TypeError(f"Expected BinaryOperation, got {operation}")
 
         if isinstance(operation.left, Constant) and not isinstance(operation.right, Constant):
             return [(operation, BinaryOperation(operation.operation, [operation.right, operation.left], operation.type, operation.tags))]

--- a/tests/pipeline/controlflowanalysis/expression_simplification/test_constant_folding.py
+++ b/tests/pipeline/controlflowanalysis/expression_simplification/test_constant_folding.py
@@ -1,8 +1,15 @@
 from contextlib import nullcontext
+from typing import Optional
 
 import pytest
-from decompiler.pipeline.controlflowanalysis.expression_simplification.constant_folding import FOLDABLE_OPERATIONS, constant_fold
-from decompiler.structures.pseudo import Constant, Float, Integer, OperationType
+from decompiler.pipeline.controlflowanalysis.expression_simplification.constant_folding import (
+    FOLDABLE_OPERATIONS,
+    UnsupportedMismatchedSizes,
+    UnsupportedOperationType,
+    UnsupportedValueType,
+    constant_fold,
+)
+from decompiler.structures.pseudo import Constant, Float, Integer, OperationType, Type
 
 
 def _c_i32(value: int) -> Constant:
@@ -21,118 +28,148 @@ def _c_float(value: float) -> Constant:
     return Constant(value, Float.float())
 
 
+def test_constant_fold_empty_list():
+    with pytest.raises(ValueError):
+        constant_fold(OperationType.plus, [], Integer.int32_t())
+
+
 @pytest.mark.parametrize(
     ["operation"],
     [(operation,) for operation in OperationType if operation not in FOLDABLE_OPERATIONS]
 )
 def test_constant_fold_invalid_operations(operation: OperationType):
-    with pytest.raises(ValueError):
-        constant_fold(operation, [])
+    with pytest.raises(UnsupportedOperationType):
+        constant_fold(operation, [_c_i32(0)], Integer.int32_t())
 
 
 @pytest.mark.parametrize(
-    ["operation", "constants", "result", "context"],
+    ["operation", "constants", "result_type", "expected_result", "context"],
     [
-        (OperationType.plus, [_c_i32(3), _c_i32(4)], _c_i32(7), nullcontext()),
-        (OperationType.plus, [_c_i32(2147483647), _c_i32(1)], _c_i32(-2147483648), nullcontext()),
-        (OperationType.plus, [_c_u32(2147483658), _c_u32(2147483652)], _c_u32(14), nullcontext()),
-        (OperationType.plus, [_c_u32(3), _c_i32(4)], None, pytest.raises(ValueError)),
-        (OperationType.plus, [_c_i32(3), _c_i16(4)], None, pytest.raises(ValueError)),
-        (OperationType.plus, [_c_i32(3)], None, pytest.raises(ValueError)),
-        (OperationType.plus, [_c_i32(3), _c_i32(3), _c_i32(3)], None, pytest.raises(ValueError)),
-
-        (OperationType.minus, [_c_i32(3), _c_i32(4)], _c_i32(-1), nullcontext()),
-        (OperationType.minus, [_c_i32(-2147483648), _c_i32(1)], _c_i32(2147483647), nullcontext()),
-        (OperationType.minus, [_c_u32(3), _c_u32(4)], _c_u32(4294967295), nullcontext()),
-        (OperationType.minus, [_c_u32(3), _c_i32(4)], None, pytest.raises(ValueError)),
-        (OperationType.minus, [_c_i32(3), _c_i16(4)], None, pytest.raises(ValueError)),
-        (OperationType.minus, [_c_i32(3)], None, pytest.raises(ValueError)),
-        (OperationType.minus, [_c_i32(3), _c_i32(3), _c_i32(3)], None, pytest.raises(ValueError)),
-
-        (OperationType.multiply, [_c_i32(3), _c_i32(4)], _c_i32(12), nullcontext()),
-        (OperationType.multiply, [_c_i32(-1073741824), _c_i32(2)], _c_i32(-2147483648), nullcontext()),
-        (OperationType.multiply, [_c_u32(3221225472), _c_u32(2)], _c_u32(2147483648), nullcontext()),
-        (OperationType.multiply, [_c_u32(3), _c_i32(4)], None, pytest.raises(ValueError)),
-        (OperationType.multiply, [_c_i32(3), _c_i16(4)], None, pytest.raises(ValueError)),
-        (OperationType.multiply, [_c_i32(3)], None, pytest.raises(ValueError)),
-        (OperationType.multiply, [_c_i32(3), _c_i32(3), _c_i32(3)], None, pytest.raises(ValueError)),
-
-        (OperationType.multiply_us, [_c_i32(3), _c_i32(4)], _c_i32(12), nullcontext()),
-        (OperationType.multiply_us, [_c_i32(-1073741824), _c_i32(2)], _c_i32(-2147483648), nullcontext()),
-        (OperationType.multiply_us, [_c_u32(3221225472), _c_u32(2)], _c_u32(2147483648), nullcontext()),
-        (OperationType.multiply_us, [_c_u32(3), _c_i32(4)], None, pytest.raises(ValueError)),
-        (OperationType.multiply_us, [_c_i32(3), _c_i16(4)], None, pytest.raises(ValueError)),
-        (OperationType.multiply_us, [_c_i32(3)], None, pytest.raises(ValueError)),
-        (OperationType.multiply_us, [_c_i32(3), _c_i32(3), _c_i32(3)], None, pytest.raises(ValueError)),
-
-        (OperationType.divide, [_c_i32(12), _c_i32(4)], _c_i32(3), nullcontext()),
-        (OperationType.divide, [_c_i32(-2147483648), _c_i32(2)], _c_i32(-1073741824), nullcontext()),
-        (OperationType.divide, [_c_u32(3), _c_i32(4)], None, pytest.raises(ValueError)),
-        (OperationType.divide, [_c_i32(3), _c_i16(4)], None, pytest.raises(ValueError)),
-        (OperationType.divide, [_c_i32(3)], None, pytest.raises(ValueError)),
-        (OperationType.divide, [_c_i32(3), _c_i32(3), _c_i32(3)], None, pytest.raises(ValueError)),
-
-        (OperationType.divide_us, [_c_i32(12), _c_i32(4)], _c_i32(3), nullcontext()),
-        (OperationType.divide_us, [_c_i32(-2147483648), _c_i32(2)], _c_i32(1073741824), nullcontext()),
-        (OperationType.divide_us, [_c_u32(3), _c_i32(4)], None, pytest.raises(ValueError)),
-        (OperationType.divide_us, [_c_i32(3), _c_i16(4)], None, pytest.raises(ValueError)),
-        (OperationType.divide_us, [_c_i32(3)], None, pytest.raises(ValueError)),
-        (OperationType.divide_us, [_c_i32(3), _c_i32(3), _c_i32(3)], None, pytest.raises(ValueError)),
-
-        (OperationType.negate, [_c_i32(3)], _c_i32(-3), nullcontext()),
-        (OperationType.negate, [_c_i32(-2147483648)], _c_i32(-2147483648), nullcontext()),
-        (OperationType.negate, [], None, pytest.raises(ValueError)),
-        (OperationType.negate, [_c_i32(3), _c_i32(3)], None, pytest.raises(ValueError)),
-
-        (OperationType.left_shift, [_c_i32(3), _c_i32(4)], _c_i32(48), nullcontext()),
-        (OperationType.left_shift, [_c_i32(1073741824), _c_i32(1)], _c_i32(-2147483648), nullcontext()),
-        (OperationType.left_shift, [_c_u32(1073741824), _c_u32(1)], _c_u32(2147483648), nullcontext()),
-        (OperationType.left_shift, [_c_i32(3)], None, pytest.raises(ValueError)),
-        (OperationType.left_shift, [_c_i32(3), _c_i32(3), _c_i32(3)], None, pytest.raises(ValueError)),
-
-        (OperationType.right_shift, [_c_i32(32), _c_i32(4)], _c_i32(2), nullcontext()),
-        (OperationType.right_shift, [_c_i32(-2147483648), _c_i32(1)], _c_i32(-1073741824), nullcontext()),
-        (OperationType.right_shift, [_c_u32(2147483648), _c_u32(1)], _c_u32(1073741824), nullcontext()),
-        (OperationType.right_shift, [_c_i32(3)], None, pytest.raises(ValueError)),
-        (OperationType.right_shift, [_c_i32(3), _c_i32(3), _c_i32(3)], None, pytest.raises(ValueError)),
-
-        (OperationType.right_shift_us, [_c_i32(32), _c_i32(4)], _c_i32(2), nullcontext()),
-        (OperationType.right_shift_us, [_c_i32(-2147483648), _c_i32(1)], _c_i32(1073741824), nullcontext()),
-        (OperationType.right_shift_us, [_c_u32(2147483648), _c_u32(1)], _c_u32(1073741824), nullcontext()),
-        (OperationType.right_shift_us, [_c_i32(3)], None, pytest.raises(ValueError)),
-        (OperationType.right_shift_us, [_c_i32(3), _c_i32(3), _c_i32(3)], None, pytest.raises(ValueError)),
-
-        (OperationType.bitwise_or, [_c_i32(85), _c_i32(34)], _c_i32(119), nullcontext()),
-        (OperationType.bitwise_or, [_c_i32(-2147483648), _c_i32(1)], _c_i32(-2147483647), nullcontext()),
-        (OperationType.bitwise_or, [_c_u32(2147483648), _c_u32(1)], _c_u32(2147483649), nullcontext()),
-        (OperationType.bitwise_or, [_c_u32(3), _c_i32(4)], None, pytest.raises(ValueError)),
-        (OperationType.bitwise_or, [_c_i32(3), _c_i16(4)], None, pytest.raises(ValueError)),
-        (OperationType.bitwise_or, [_c_i32(3)], None, pytest.raises(ValueError)),
-        (OperationType.bitwise_or, [_c_i32(3), _c_i32(3), _c_i32(3)], None, pytest.raises(ValueError)),
-
-        (OperationType.bitwise_and, [_c_i32(85), _c_i32(51)], _c_i32(17), nullcontext()),
-        (OperationType.bitwise_and, [_c_i32(-2147483647), _c_i32(3)], _c_i32(1), nullcontext()),
-        (OperationType.bitwise_and, [_c_u32(2147483649), _c_u32(3)], _c_u32(1), nullcontext()),
-        (OperationType.bitwise_and, [_c_u32(3), _c_i32(4)], None, pytest.raises(ValueError)),
-        (OperationType.bitwise_and, [_c_i32(3), _c_i16(4)], None, pytest.raises(ValueError)),
-        (OperationType.bitwise_and, [_c_i32(3)], None, pytest.raises(ValueError)),
-        (OperationType.bitwise_and, [_c_i32(3), _c_i32(3), _c_i32(3)], None, pytest.raises(ValueError)),
-
-        (OperationType.bitwise_xor, [_c_i32(85), _c_i32(51)], _c_i32(102), nullcontext()),
-        (OperationType.bitwise_xor, [_c_i32(-2147483647), _c_i32(-2147483646)], _c_i32(3), nullcontext()),
-        (OperationType.bitwise_xor, [_c_u32(2147483649), _c_u32(2147483650)], _c_u32(3), nullcontext()),
-        (OperationType.bitwise_xor, [_c_u32(3), _c_i32(4)], None, pytest.raises(ValueError)),
-        (OperationType.bitwise_xor, [_c_i32(3), _c_i16(4)], None, pytest.raises(ValueError)),
-        (OperationType.bitwise_xor, [_c_i32(3)], None, pytest.raises(ValueError)),
-        (OperationType.bitwise_xor, [_c_i32(3), _c_i32(3), _c_i32(3)], None, pytest.raises(ValueError)),
-
-        (OperationType.bitwise_not, [_c_i32(6)], _c_i32(-7), nullcontext()),
-        (OperationType.bitwise_not, [_c_i32(-2147483648)], _c_i32(2147483647), nullcontext()),
-        (OperationType.bitwise_not, [_c_u32(2147483648)], _c_u32(2147483647), nullcontext()),
-        (OperationType.bitwise_not, [], None, pytest.raises(ValueError)),
-        (OperationType.bitwise_not, [_c_i32(3), _c_i32(3)], None, pytest.raises(ValueError)),
+        (OperationType.plus, [_c_i32(0), _c_i32(0)], Integer.int32_t(), _c_i32(0), nullcontext()),
+        (OperationType.plus, [_c_float(0.0), _c_float(0.0)], Float.float(), _c_float(0.0), pytest.raises(UnsupportedValueType)),
+        (OperationType.plus, [_c_i32(0), _c_float(0.0)], Integer.int32_t(), _c_i32(0), pytest.raises(UnsupportedValueType)),
     ]
 )
-def test_constant_fold(operation: OperationType, constants: list[Constant], result: Constant, context):
+def test_constant_fold_invalid_value_type(
+        operation: OperationType,
+        constants: list[Constant],
+        result_type: Type,
+        expected_result: Optional[Constant],
+        context
+):
     with context:
-        assert constant_fold(operation, constants) == result
+        assert constant_fold(operation, constants, result_type) == expected_result
+
+
+@pytest.mark.parametrize(
+    ["operation", "constants", "result_type", "expected_result", "context"],
+    [
+        (OperationType.plus, [_c_i32(3), _c_i32(4)], Integer.int32_t(), _c_i32(7), nullcontext()),
+        (OperationType.plus, [_c_i32(2147483647), _c_i32(1)], Integer.int32_t(), _c_i32(-2147483648), nullcontext()),
+        (OperationType.plus, [_c_u32(2147483658), _c_u32(2147483652)], Integer.uint32_t(), _c_u32(14), nullcontext()),
+        (OperationType.plus, [_c_u32(3), _c_i32(4)], Integer.int32_t(), _c_i32(7), nullcontext()),
+        (OperationType.plus, [_c_i32(3), _c_i16(4)], Integer.int32_t(), None, pytest.raises(UnsupportedMismatchedSizes)),
+        (OperationType.plus, [_c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+        (OperationType.plus, [_c_i32(3), _c_i32(3), _c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+
+        (OperationType.minus, [_c_i32(3), _c_i32(4)], Integer.int32_t(), _c_i32(-1), nullcontext()),
+        (OperationType.minus, [_c_i32(-2147483648), _c_i32(1)], Integer.int32_t(), _c_i32(2147483647), nullcontext()),
+        (OperationType.minus, [_c_u32(3), _c_u32(4)], Integer.uint32_t(), _c_u32(4294967295), nullcontext()),
+        (OperationType.minus, [_c_u32(3), _c_i32(4)], Integer.int32_t(), _c_i32(-1), nullcontext()),
+        (OperationType.minus, [_c_i32(3), _c_i16(4)], Integer.int32_t(), None, pytest.raises(UnsupportedMismatchedSizes)),
+        (OperationType.minus, [_c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+        (OperationType.minus, [_c_i32(3), _c_i32(3), _c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+
+        (OperationType.multiply, [_c_i32(3), _c_i32(4)], Integer.int32_t(), _c_i32(12), nullcontext()),
+        (OperationType.multiply, [_c_i32(-1073741824), _c_i32(2)], Integer.int32_t(), _c_i32(-2147483648), nullcontext()),
+        (OperationType.multiply, [_c_u32(3221225472), _c_u32(2)], Integer.uint32_t(), _c_u32(2147483648), nullcontext()),
+        (OperationType.multiply, [_c_u32(3), _c_i32(4)], Integer.int32_t(), _c_i32(12), nullcontext()),
+        (OperationType.multiply, [_c_i32(3), _c_i16(4)], Integer.int32_t(), None, pytest.raises(UnsupportedMismatchedSizes)),
+        (OperationType.multiply, [_c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+        (OperationType.multiply, [_c_i32(3), _c_i32(3), _c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+
+        (OperationType.multiply_us, [_c_i32(3), _c_i32(4)], Integer.int32_t(), _c_i32(12), nullcontext()),
+        (OperationType.multiply_us, [_c_i32(-1073741824), _c_i32(2)], Integer.int32_t(), _c_i32(-2147483648), nullcontext()),
+        (OperationType.multiply_us, [_c_u32(3221225472), _c_u32(2)], Integer.uint32_t(), _c_u32(2147483648), nullcontext()),
+        (OperationType.multiply_us, [_c_u32(3), _c_i32(4)], Integer.int32_t(), _c_i32(12), nullcontext()),
+        (OperationType.multiply_us, [_c_i32(3), _c_i16(4)], Integer.int32_t(), None, pytest.raises(UnsupportedMismatchedSizes)),
+        (OperationType.multiply_us, [_c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+        (OperationType.multiply_us, [_c_i32(3), _c_i32(3), _c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+
+        (OperationType.divide, [_c_i32(12), _c_i32(4)], Integer.int32_t(), _c_i32(3), nullcontext()),
+        (OperationType.divide, [_c_i32(-2147483648), _c_i32(2)], Integer.int32_t(), _c_i32(-1073741824), nullcontext()),
+        (OperationType.divide, [_c_u32(3), _c_i32(4)], Integer.int32_t(), _c_i32(0), nullcontext()),
+        (OperationType.divide, [_c_i32(3), _c_i16(4)], Integer.int32_t(), None, pytest.raises(UnsupportedMismatchedSizes)),
+        (OperationType.divide, [_c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+        (OperationType.divide, [_c_i32(3), _c_i32(3), _c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+
+        (OperationType.divide_us, [_c_i32(12), _c_i32(4)], Integer.int32_t(), _c_i32(3), nullcontext()),
+        (OperationType.divide_us, [_c_i32(-2147483648), _c_i32(2)], Integer.int32_t(), _c_i32(1073741824), nullcontext()),
+        (OperationType.divide_us, [_c_u32(3), _c_i32(4)], Integer.int32_t(), _c_i32(0), nullcontext()),
+        (OperationType.divide_us, [_c_i32(3), _c_i16(4)], Integer.int32_t(), None, pytest.raises(UnsupportedMismatchedSizes)),
+        (OperationType.divide_us, [_c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+        (OperationType.divide_us, [_c_i32(3), _c_i32(3), _c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+
+        (OperationType.negate, [_c_i32(3)], Integer.int32_t(), _c_i32(-3), nullcontext()),
+        (OperationType.negate, [_c_i32(-2147483648)], Integer.int32_t(), _c_i32(-2147483648), nullcontext()),
+        (OperationType.negate, [], Integer.int32_t(), None, pytest.raises(ValueError)),
+        (OperationType.negate, [_c_i32(3), _c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+
+        (OperationType.left_shift, [_c_i32(3), _c_i32(4)], Integer.int32_t(), _c_i32(48), nullcontext()),
+        (OperationType.left_shift, [_c_i32(1073741824), _c_i32(1)], Integer.int32_t(), _c_i32(-2147483648), nullcontext()),
+        (OperationType.left_shift, [_c_u32(1073741824), _c_u32(1)], Integer.uint32_t(), _c_u32(2147483648), nullcontext()),
+        (OperationType.left_shift, [_c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+        (OperationType.left_shift, [_c_i32(3), _c_i32(3), _c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+
+        (OperationType.right_shift, [_c_i32(32), _c_i32(4)], Integer.int32_t(), _c_i32(2), nullcontext()),
+        (OperationType.right_shift, [_c_i32(-2147483648), _c_i32(1)], Integer.int32_t(), _c_i32(-1073741824), nullcontext()),
+        (OperationType.right_shift, [_c_u32(2147483648), _c_u32(1)], Integer.uint32_t(), _c_u32(1073741824), nullcontext()),
+        (OperationType.right_shift, [_c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+        (OperationType.right_shift, [_c_i32(3), _c_i32(3), _c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+
+        (OperationType.right_shift_us, [_c_i32(32), _c_i32(4)], Integer.int32_t(), _c_i32(2), nullcontext()),
+        (OperationType.right_shift_us, [_c_i32(-2147483648), _c_i32(1)], Integer.int32_t(), _c_i32(1073741824), nullcontext()),
+        (OperationType.right_shift_us, [_c_u32(2147483648), _c_u32(1)], Integer.uint32_t(), _c_u32(1073741824), nullcontext()),
+        (OperationType.right_shift_us, [_c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+        (OperationType.right_shift_us, [_c_i32(3), _c_i32(3), _c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+
+        (OperationType.bitwise_or, [_c_i32(85), _c_i32(34)], Integer.int32_t(), _c_i32(119), nullcontext()),
+        (OperationType.bitwise_or, [_c_i32(-2147483648), _c_i32(1)], Integer.int32_t(), _c_i32(-2147483647), nullcontext()),
+        (OperationType.bitwise_or, [_c_u32(2147483648), _c_u32(1)], Integer.uint32_t(), _c_u32(2147483649), nullcontext()),
+        (OperationType.bitwise_or, [_c_u32(3), _c_i32(4)], Integer.int32_t(), _c_i32(7), nullcontext()),
+        (OperationType.bitwise_or, [_c_i32(3), _c_i16(4)], Integer.int32_t(), None, pytest.raises(UnsupportedMismatchedSizes)),
+        (OperationType.bitwise_or, [_c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+        (OperationType.bitwise_or, [_c_i32(3), _c_i32(3), _c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+
+        (OperationType.bitwise_and, [_c_i32(85), _c_i32(51)], Integer.int32_t(), _c_i32(17), nullcontext()),
+        (OperationType.bitwise_and, [_c_i32(-2147483647), _c_i32(3)], Integer.int32_t(), _c_i32(1), nullcontext()),
+        (OperationType.bitwise_and, [_c_u32(2147483649), _c_u32(3)], Integer.uint32_t(), _c_u32(1), nullcontext()),
+        (OperationType.bitwise_and, [_c_u32(3), _c_i32(4)], Integer.int32_t(), _c_i32(0), nullcontext()),
+        (OperationType.bitwise_and, [_c_i32(3), _c_i16(4)], Integer.int32_t(), None, pytest.raises(UnsupportedMismatchedSizes)),
+        (OperationType.bitwise_and, [_c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+        (OperationType.bitwise_and, [_c_i32(3), _c_i32(3), _c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+
+        (OperationType.bitwise_xor, [_c_i32(85), _c_i32(51)], Integer.int32_t(), _c_i32(102), nullcontext()),
+        (OperationType.bitwise_xor, [_c_i32(-2147483647), _c_i32(-2147483646)], Integer.int32_t(), _c_i32(3), nullcontext()),
+        (OperationType.bitwise_xor, [_c_u32(2147483649), _c_u32(2147483650)], Integer.uint32_t(), _c_u32(3), nullcontext()),
+        (OperationType.bitwise_xor, [_c_u32(3), _c_i32(4)], Integer.int32_t(), _c_i32(7), nullcontext()),
+        (OperationType.bitwise_xor, [_c_i32(3), _c_i16(4)], Integer.int32_t(), None, pytest.raises(UnsupportedMismatchedSizes)),
+        (OperationType.bitwise_xor, [_c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+        (OperationType.bitwise_xor, [_c_i32(3), _c_i32(3), _c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+
+        (OperationType.bitwise_not, [_c_i32(6)], Integer.int32_t(), _c_i32(-7), nullcontext()),
+        (OperationType.bitwise_not, [_c_i32(-2147483648)], Integer.int32_t(), _c_i32(2147483647), nullcontext()),
+        (OperationType.bitwise_not, [_c_u32(2147483648)], Integer.uint32_t(), _c_u32(2147483647), nullcontext()),
+        (OperationType.bitwise_not, [], Integer.int32_t(), None, pytest.raises(ValueError)),
+        (OperationType.bitwise_not, [_c_i32(3), _c_i32(3)], Integer.int32_t(), None, pytest.raises(ValueError)),
+    ]
+)
+def test_constant_fold(
+        operation: OperationType,
+        constants: list[Constant],
+        result_type: Type,
+        expected_result: Optional[Constant],
+        context
+):
+    with context:
+        assert constant_fold(operation, constants, result_type) == expected_result


### PR DESCRIPTION
This pr improves the error handling of the expression simplifcation stage, especially with collapsing of constants. Previously there were some exceptions, which were being thrown on valid input data, like adding of pointer constants with integer constants.
Additionally all errors caused by simplification rules are now catched and properly handled.