### PR TITLE
[Code Quality] Remove wildcard import

### DIFF
--- a/decompiler/pipeline/dataflowanalysis/dead_loop_elimination.py
+++ b/decompiler/pipeline/dataflowanalysis/dead_loop_elimination.py
@@ -4,8 +4,8 @@ from typing import Dict, Generator, Optional, Tuple, Union
 
 from decompiler.pipeline.preprocessing.util import _init_basicblocks_of_definition, _init_maps
 from decompiler.pipeline.stage import PipelineStage
-from decompiler.structures.graphs.cfg import BasicBlock, ControlFlowGraph, GraphEdgeInterface
-from decompiler.structures.graphs.interface import GraphInterface
+from decompiler.structures.graphs.cfg import BasicBlock, ControlFlowGraph
+from decompiler.structures.graphs.interface import GraphEdgeInterface, GraphInterface
 from decompiler.structures.maps import DefMap, UseMap
 from decompiler.structures.pseudo.delogic_logic import DelogicConverter
 from decompiler.structures.pseudo.expressions import Constant, Variable

--- a/decompiler/structures/graphs/cfg.py
+++ b/decompiler/structures/graphs/cfg.py
@@ -2,13 +2,22 @@
 from __future__ import annotations
 
 from itertools import chain
-from typing import Dict, Set
+from typing import Dict, Iterator, List, Optional, Set
 
-from decompiler.structures.pseudo import Assignment, Condition, Instruction, Variable
+from decompiler.structures.pseudo import Assignment, Condition, Expression, Instruction, Variable
 from networkx import DiGraph
 
 from .basicblock import BasicBlock
-from .branches import *
+from .branches import (
+    BasicBlockEdge,
+    BasicBlockEdgeCondition,
+    ConditionalEdge,
+    FalseCase,
+    IndirectEdge,
+    SwitchCase,
+    TrueCase,
+    UnconditionalEdge,
+)
 from .classifiedgraph import ClassifiedGraph
 
 


### PR DESCRIPTION
This commit removes the wildcard import `from .branches import *` and replaces it with explicit imports.

Reasons to do so:
- The wildcard import unnecessarily pollutes the namespace of `cfg` with all of `branch`es imports.
- The aforementioned pollution caused typecheckers and linters to partially fail because of weird side effects.
- "Explicit is better than implicit"  (The Zen of Python)