### PR TITLE
Formatted with new Black version

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,5 @@
 """Main plugin file registering plugin commands in bianryninja."""
+
 from logging import info, warning
 from os.path import dirname, realpath
 from sys import path

--- a/decompiler/backend/codegenerator.py
+++ b/decompiler/backend/codegenerator.py
@@ -1,4 +1,5 @@
 """Module in charge of bundling all classes utilized to generate c-code from an AST."""
+
 from string import Template
 from typing import Iterable, List
 

--- a/decompiler/backend/variabledeclarations.py
+++ b/decompiler/backend/variabledeclarations.py
@@ -1,4 +1,5 @@
 """Module containing the visitors used to generate variable declarations."""
+
 from collections import defaultdict
 from typing import Iterable, Iterator, List
 

--- a/decompiler/frontend/__init__.py
+++ b/decompiler/frontend/__init__.py
@@ -1,4 +1,5 @@
 """module for anything pipeline related."""
+
 from .binaryninja.frontend import BinaryninjaFrontend
 from .frontend import Frontend
 from .lifter import Lifter

--- a/decompiler/frontend/binaryninja/frontend.py
+++ b/decompiler/frontend/binaryninja/frontend.py
@@ -1,4 +1,5 @@
 """Class implementing the main binaryninja frontend interface."""
+
 from __future__ import annotations
 
 import logging

--- a/decompiler/frontend/binaryninja/handlers/__init__.py
+++ b/decompiler/frontend/binaryninja/handlers/__init__.py
@@ -1,4 +1,5 @@
 """Main module containing all binaryninja handlers."""
+
 from .assignments import AssignmentHandler
 from .binary import BinaryOperationHandler
 from .calls import CallHandler

--- a/decompiler/frontend/binaryninja/handlers/assignments.py
+++ b/decompiler/frontend/binaryninja/handlers/assignments.py
@@ -1,4 +1,5 @@
 """Module implementing the AssignmentHandler for binaryninja."""
+
 import logging
 from functools import partial
 

--- a/decompiler/frontend/binaryninja/handlers/binary.py
+++ b/decompiler/frontend/binaryninja/handlers/binary.py
@@ -1,4 +1,5 @@
 """Module implementing the handler for binaryninja's binary operations."""
+
 from functools import partial
 
 from binaryninja import MediumLevelILInstruction, mediumlevelil

--- a/decompiler/frontend/binaryninja/handlers/calls.py
+++ b/decompiler/frontend/binaryninja/handlers/calls.py
@@ -1,4 +1,5 @@
 """Module implementing the binaryninja CallHandler."""
+
 from functools import partial
 from typing import List
 

--- a/decompiler/frontend/binaryninja/handlers/conditions.py
+++ b/decompiler/frontend/binaryninja/handlers/conditions.py
@@ -1,4 +1,5 @@
 """Module implementing the ConditionHandler class."""
+
 from functools import partial
 
 from binaryninja import mediumlevelil

--- a/decompiler/frontend/binaryninja/handlers/constants.py
+++ b/decompiler/frontend/binaryninja/handlers/constants.py
@@ -1,4 +1,5 @@
 """Module implementing the ConstantHandler for the binaryninja frontend."""
+
 import math
 
 from binaryninja import BinaryView, DataVariable, SectionSemantics, SymbolType, Type, mediumlevelil

--- a/decompiler/frontend/binaryninja/handlers/controlflow.py
+++ b/decompiler/frontend/binaryninja/handlers/controlflow.py
@@ -1,4 +1,5 @@
 """Module implementing the ConditionHandler class."""
+
 from binaryninja import mediumlevelil
 from decompiler.frontend.lifter import Handler
 from decompiler.structures.pseudo import Branch, Condition, Constant, IndirectBranch, OperationType, Return

--- a/decompiler/frontend/binaryninja/handlers/globals.py
+++ b/decompiler/frontend/binaryninja/handlers/globals.py
@@ -1,4 +1,5 @@
 """Module implementing the ConstantHandler for the binaryninja frontend."""
+
 from typing import Callable, Optional, Tuple, Union
 
 from binaryninja import BinaryView, DataVariable, Endianness, MediumLevelILInstruction, Type

--- a/decompiler/frontend/binaryninja/handlers/phi.py
+++ b/decompiler/frontend/binaryninja/handlers/phi.py
@@ -1,4 +1,5 @@
 """Module implementing lifting of phi and memphi instructions."""
+
 from typing import List
 
 from binaryninja import MediumLevelILMemPhi, MediumLevelILVarPhi

--- a/decompiler/frontend/binaryninja/handlers/symbols.py
+++ b/decompiler/frontend/binaryninja/handlers/symbols.py
@@ -1,4 +1,5 @@
 """Module implementing lifting of binaryninja symbols."""
+
 from logging import warning
 from typing import Union
 

--- a/decompiler/frontend/binaryninja/handlers/unary.py
+++ b/decompiler/frontend/binaryninja/handlers/unary.py
@@ -1,4 +1,5 @@
 """Module implementing the UnaryOperationHandler."""
+
 import logging
 from functools import partial
 from typing import Union

--- a/decompiler/frontend/binaryninja/handlers/variables.py
+++ b/decompiler/frontend/binaryninja/handlers/variables.py
@@ -1,4 +1,5 @@
 """Module implementing variable lifting for the binaryninja observer lifer."""
+
 from typing import Optional
 
 from binaryninja import (

--- a/decompiler/frontend/binaryninja/lifter.py
+++ b/decompiler/frontend/binaryninja/lifter.py
@@ -1,4 +1,5 @@
 """Module implementing the BinaryNinjaLifter of the binaryninja frontend."""
+
 from logging import warning
 from typing import Optional, Tuple, Union
 

--- a/decompiler/frontend/binaryninja/parser.py
+++ b/decompiler/frontend/binaryninja/parser.py
@@ -1,4 +1,5 @@
 """Implements the parser for the binaryninja frontend."""
+
 from logging import info, warning
 from typing import Dict, Iterator, List, Tuple
 

--- a/decompiler/frontend/binaryninja/tests.py
+++ b/decompiler/frontend/binaryninja/tests.py
@@ -1,4 +1,5 @@
 """WIP test suite for binaryninja lifter."""
+
 from os import listdir
 from os.path import abspath, dirname, isfile, join, realpath
 from sys import path

--- a/decompiler/frontend/frontend.py
+++ b/decompiler/frontend/frontend.py
@@ -1,4 +1,5 @@
 """Module implementing the interface for different frontends."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/decompiler/frontend/lifter.py
+++ b/decompiler/frontend/lifter.py
@@ -1,4 +1,5 @@
 """Interface for frontend lifters."""
+
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, Type, TypeVar
 

--- a/decompiler/frontend/parser.py
+++ b/decompiler/frontend/parser.py
@@ -1,4 +1,5 @@
 """Module defining the parser interface."""
+
 from abc import ABC, abstractmethod
 
 from decompiler.structures.graphs.cfg import ControlFlowGraph

--- a/decompiler/logger.py
+++ b/decompiler/logger.py
@@ -1,4 +1,5 @@
 """Module in charge of logger initialization and settings."""
+
 import logging.config
 from typing import Optional
 

--- a/decompiler/pipeline/commons/livenessanalysis.py
+++ b/decompiler/pipeline/commons/livenessanalysis.py
@@ -1,4 +1,5 @@
 """Liveness Analysis due to Brandner et al. : Algorithms 4 (Compute liveness sets by exploring paths from variable uses"""
+
 from collections import defaultdict
 from typing import DefaultDict
 

--- a/decompiler/pipeline/controlflowanalysis/expression_simplification/constant_folding.py
+++ b/decompiler/pipeline/controlflowanalysis/expression_simplification/constant_folding.py
@@ -17,7 +17,6 @@ class UnsupportedOperationType(Exception):
 
 
 class UnsupportedValueType(Exception):
-
     """Indicates that the value type of one constant is not supported."""
 
     pass

--- a/decompiler/pipeline/controlflowanalysis/readability_based_refinement.py
+++ b/decompiler/pipeline/controlflowanalysis/readability_based_refinement.py
@@ -1,4 +1,5 @@
 """Module implementing various readability based refinements."""
+
 from __future__ import annotations
 
 from typing import Union

--- a/decompiler/pipeline/controlflowanalysis/restructuring.py
+++ b/decompiler/pipeline/controlflowanalysis/restructuring.py
@@ -1,6 +1,7 @@
 """
 Module for pattern independent restructuring
 """
+
 from __future__ import annotations
 
 import logging

--- a/decompiler/pipeline/controlflowanalysis/restructuring_commons/ast_processor.py
+++ b/decompiler/pipeline/controlflowanalysis/restructuring_commons/ast_processor.py
@@ -1,4 +1,5 @@
 """Module for AST processing steps."""
+
 import logging
 from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 

--- a/decompiler/pipeline/controlflowanalysis/restructuring_commons/condition_based_refinement.py
+++ b/decompiler/pipeline/controlflowanalysis/restructuring_commons/condition_based_refinement.py
@@ -1,6 +1,7 @@
 """
 Module for Condition Based Refinement
 """
+
 from itertools import combinations
 from typing import Iterator, List, Optional, Set, Tuple
 

--- a/decompiler/pipeline/controlflowanalysis/restructuring_commons/graphslice.py
+++ b/decompiler/pipeline/controlflowanalysis/restructuring_commons/graphslice.py
@@ -1,4 +1,5 @@
 """Module to compute graph slices."""
+
 from __future__ import annotations
 
 from typing import Iterator, List, Set

--- a/decompiler/pipeline/controlflowanalysis/restructuring_commons/loop_structurer.py
+++ b/decompiler/pipeline/controlflowanalysis/restructuring_commons/loop_structurer.py
@@ -1,4 +1,5 @@
 """Module to structure Loops"""
+
 from typing import Optional
 
 from decompiler.pipeline.controlflowanalysis.restructuring_commons.ast_processor import LoopProcessor

--- a/decompiler/pipeline/controlflowanalysis/restructuring_commons/region_finder/acyclic_region_finder.py
+++ b/decompiler/pipeline/controlflowanalysis/restructuring_commons/region_finder/acyclic_region_finder.py
@@ -1,4 +1,5 @@
 """Module to find restructurable regions."""
+
 from __future__ import annotations
 
 from abc import abstractmethod

--- a/decompiler/pipeline/dataflowanalysis/array_access_detection.py
+++ b/decompiler/pipeline/dataflowanalysis/array_access_detection.py
@@ -1,4 +1,5 @@
 """Module implementing detection of array element accesses"""
+
 import logging
 from collections import defaultdict
 from dataclasses import dataclass, field

--- a/decompiler/pipeline/dataflowanalysis/common_subexpression_elimination.py
+++ b/decompiler/pipeline/dataflowanalysis/common_subexpression_elimination.py
@@ -1,4 +1,5 @@
 """Module implementing common subexpression elimination."""
+
 from __future__ import annotations
 
 from collections import defaultdict, deque

--- a/decompiler/pipeline/dataflowanalysis/dead_loop_elimination.py
+++ b/decompiler/pipeline/dataflowanalysis/dead_loop_elimination.py
@@ -1,4 +1,5 @@
 """Module implementing the DeadLoopElimination pipeline stage."""
+
 from logging import info, warning
 from typing import Dict, Generator, Optional, Tuple, Union
 

--- a/decompiler/pipeline/dataflowanalysis/dead_path_elimination.py
+++ b/decompiler/pipeline/dataflowanalysis/dead_path_elimination.py
@@ -1,4 +1,5 @@
 """Module implementing the DeadPathElimination pipeline stage."""
+
 from logging import info, warning
 from typing import Iterator, Optional, Set, Union
 

--- a/decompiler/pipeline/dataflowanalysis/deadcodeelimination.py
+++ b/decompiler/pipeline/dataflowanalysis/deadcodeelimination.py
@@ -1,4 +1,5 @@
 """Module implementing code elimination based on Hols et al."""
+
 from collections import defaultdict, namedtuple
 from typing import DefaultDict, Optional, Set
 

--- a/decompiler/pipeline/dataflowanalysis/identity_elimination.py
+++ b/decompiler/pipeline/dataflowanalysis/identity_elimination.py
@@ -1,4 +1,5 @@
 """Module implementing a pipeline stage eliminating congruent variables."""
+
 from __future__ import annotations
 
 from collections import defaultdict, namedtuple

--- a/decompiler/pipeline/dataflowanalysis/type_propagation.py
+++ b/decompiler/pipeline/dataflowanalysis/type_propagation.py
@@ -1,4 +1,5 @@
 """Module implementing horizontal type propagation as a pipeline stage."""
+
 from __future__ import annotations
 
 from collections import Counter, defaultdict

--- a/decompiler/pipeline/expressions/deadcomponentpruner.py
+++ b/decompiler/pipeline/expressions/deadcomponentpruner.py
@@ -1,4 +1,5 @@
 """Module implementing Dead code elimination based on ExpressionGraphs."""
+
 from typing import Iterator
 
 from decompiler.pipeline.stage import PipelineStage

--- a/decompiler/pipeline/expressions/edgepruner.py
+++ b/decompiler/pipeline/expressions/edgepruner.py
@@ -1,4 +1,5 @@
 """Module implementing common subexpression elimination on ExpressionGraphs."""
+
 from typing import Iterator, List
 
 from decompiler.pipeline.stage import PipelineStage

--- a/decompiler/pipeline/pipeline.py
+++ b/decompiler/pipeline/pipeline.py
@@ -1,4 +1,5 @@
 """Module containing pipeline definitions for the decompiler."""
+
 from __future__ import annotations
 
 from logging import debug, error, warning

--- a/decompiler/pipeline/preprocessing/coherence.py
+++ b/decompiler/pipeline/preprocessing/coherence.py
@@ -1,4 +1,5 @@
 """Module implementing frontend data harmonization."""
+
 from itertools import chain
 from logging import info
 from typing import Dict, Iterator, List

--- a/decompiler/pipeline/preprocessing/compiler_idiom_handling.py
+++ b/decompiler/pipeline/preprocessing/compiler_idiom_handling.py
@@ -1,4 +1,5 @@
 """Module for handling compiler idioms that have already been marked in BinaryNinja"""
+
 import logging
 from dataclasses import dataclass
 from typing import Iterable, List, Optional

--- a/decompiler/pipeline/preprocessing/missing_definitions.py
+++ b/decompiler/pipeline/preprocessing/missing_definitions.py
@@ -1,4 +1,5 @@
 """Module dedicated to insert definitions for otherwise definitionless values."""
+
 from collections import defaultdict
 from logging import error
 from typing import DefaultDict, Dict, List, Optional, Set, Tuple, Union

--- a/decompiler/pipeline/preprocessing/phi_predecessors.py
+++ b/decompiler/pipeline/preprocessing/phi_predecessors.py
@@ -1,4 +1,5 @@
 """Module fixing the Control Glow Graph such that it contains all information we need for our analysis."""
+
 from typing import Dict, List, Optional
 
 from decompiler.pipeline.stage import PipelineStage

--- a/decompiler/pipeline/preprocessing/register_pair_handling.py
+++ b/decompiler/pipeline/preprocessing/register_pair_handling.py
@@ -1,4 +1,5 @@
 """Module to handle Register pairs."""
+
 from __future__ import annotations
 
 from collections import namedtuple

--- a/decompiler/pipeline/preprocessing/remove_stack_canary.py
+++ b/decompiler/pipeline/preprocessing/remove_stack_canary.py
@@ -1,4 +1,5 @@
 """Module for removing ELF stack canaries."""
+
 from typing import Iterator
 
 from decompiler.pipeline.stage import PipelineStage

--- a/decompiler/pipeline/preprocessing/switch_variable_detection.py
+++ b/decompiler/pipeline/preprocessing/switch_variable_detection.py
@@ -1,4 +1,5 @@
 """Module for finding variable relevant to switch"""
+
 from typing import Optional
 
 from decompiler.pipeline.stage import PipelineStage

--- a/decompiler/pipeline/preprocessing/util.py
+++ b/decompiler/pipeline/preprocessing/util.py
@@ -1,4 +1,5 @@
 """Helper functions for modules in the preprocessing pipeline."""
+
 from collections import defaultdict
 from typing import DefaultDict, Dict, Set, Tuple
 

--- a/decompiler/pipeline/ssa/outofssatranslation.py
+++ b/decompiler/pipeline/ssa/outofssatranslation.py
@@ -1,4 +1,5 @@
 """Module implementing Out of SSA."""
+
 import logging
 from collections import defaultdict
 from configparser import NoOptionError

--- a/decompiler/pipeline/ssa/phi_cleaner.py
+++ b/decompiler/pipeline/ssa/phi_cleaner.py
@@ -1,4 +1,5 @@
 """Module for removing unnecessary Phi-functions in Out of SSA."""
+
 from typing import Dict, Iterator, List
 
 from decompiler.pipeline.ssa.phi_dependency_graph import PhiDependencyGraph

--- a/decompiler/pipeline/ssa/phi_dependency_resolver.py
+++ b/decompiler/pipeline/ssa/phi_dependency_resolver.py
@@ -1,4 +1,5 @@
 """Module for removing circular dependency of Phi-functions in Out of SSA."""
+
 import logging
 from typing import Dict, List
 

--- a/decompiler/pipeline/ssa/phi_lifting.py
+++ b/decompiler/pipeline/ssa/phi_lifting.py
@@ -1,4 +1,5 @@
 """Module for removing Phi-functions by lifting in Out of SSA."""
+
 import logging
 from typing import DefaultDict, Iterator, List, Optional
 

--- a/decompiler/pipeline/ssa/variable_renaming.py
+++ b/decompiler/pipeline/ssa/variable_renaming.py
@@ -1,4 +1,5 @@
 """Module for renaming variables in Out of SSA."""
+
 import logging
 from collections import defaultdict
 from dataclasses import dataclass, field

--- a/decompiler/pipeline/stage.py
+++ b/decompiler/pipeline/stage.py
@@ -1,4 +1,5 @@
 """Module implementing the PipelineStage interface."""
+
 from abc import ABC, abstractmethod
 
 from decompiler.task import DecompilerTask

--- a/decompiler/structures/ast/reachability_graph.py
+++ b/decompiler/structures/ast/reachability_graph.py
@@ -1,4 +1,5 @@
 """Module to handle the reaches attribute using graphs."""
+
 from __future__ import annotations
 
 from itertools import chain, permutations, product

--- a/decompiler/structures/graphs/basic.py
+++ b/decompiler/structures/graphs/basic.py
@@ -1,4 +1,5 @@
 """Module implementing basic nodes based on aa given (printable) python object."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/decompiler/structures/graphs/basicblock.py
+++ b/decompiler/structures/graphs/basicblock.py
@@ -1,4 +1,5 @@
 """Module defining the BasicBlock class utilized in ControlFlowGraphs."""
+
 from __future__ import annotations
 
 from enum import Enum

--- a/decompiler/structures/graphs/branches.py
+++ b/decompiler/structures/graphs/branches.py
@@ -1,4 +1,5 @@
 """Module defining the various branches between BasicBlocks used in ControlFlowGraphs."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/decompiler/structures/graphs/cfg.py
+++ b/decompiler/structures/graphs/cfg.py
@@ -1,4 +1,5 @@
 """Module defining a control flow graph with the graph interface."""
+
 from __future__ import annotations
 
 from itertools import chain

--- a/decompiler/structures/graphs/classifiedgraph.py
+++ b/decompiler/structures/graphs/classifiedgraph.py
@@ -1,4 +1,5 @@
 """Module implementing edge classification for NetworkXGraph."""
+
 from __future__ import annotations
 
 from collections import defaultdict

--- a/decompiler/structures/graphs/expressiongraph.py
+++ b/decompiler/structures/graphs/expressiongraph.py
@@ -1,4 +1,5 @@
 """Module defining the ExpressionGraph used for various pipeline stages."""
+
 from __future__ import annotations
 
 from decompiler.structures.graphs.cfg import ControlFlowGraph

--- a/decompiler/structures/graphs/interface/__init__.py
+++ b/decompiler/structures/graphs/interface/__init__.py
@@ -1,3 +1,4 @@
 """Module defining the graph interface."""
+
 from .graph import EDGE, NODE, GraphEdgeInterface, GraphInterface, GraphNodeInterface
 from .rooted import RootedGraphInterface

--- a/decompiler/structures/graphs/interface/edge.py
+++ b/decompiler/structures/graphs/interface/edge.py
@@ -1,4 +1,5 @@
 """Module defining the edge interface linking node objects."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/decompiler/structures/graphs/interface/graph.py
+++ b/decompiler/structures/graphs/interface/graph.py
@@ -1,4 +1,5 @@
 """Defines a generic graph interface suitable for multiple graph backends."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/decompiler/structures/graphs/interface/node.py
+++ b/decompiler/structures/graphs/interface/node.py
@@ -1,4 +1,5 @@
 """Module defining the most basic node interface."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/decompiler/structures/graphs/interface/rooted.py
+++ b/decompiler/structures/graphs/interface/rooted.py
@@ -1,4 +1,5 @@
 """Module defining the interface for rooted graphs."""
+
 from abc import ABC, abstractmethod
 from typing import Optional
 

--- a/decompiler/structures/graphs/nxgraph.py
+++ b/decompiler/structures/graphs/nxgraph.py
@@ -1,4 +1,5 @@
 """Module implementing networkx as a graph backend."""
+
 from __future__ import annotations
 
 from typing import Dict, Iterator, Optional, Tuple, TypeVar

--- a/decompiler/structures/graphs/rootedgraph.py
+++ b/decompiler/structures/graphs/rootedgraph.py
@@ -1,4 +1,5 @@
 """Module implementing a rooted graph with buffered dominator tree."""
+
 from __future__ import annotations
 
 from typing import Iterable, Optional, Tuple

--- a/decompiler/structures/interferencegraph.py
+++ b/decompiler/structures/interferencegraph.py
@@ -1,4 +1,5 @@
 """Class for the Interference Graph"""
+
 from __future__ import annotations
 
 from itertools import combinations

--- a/decompiler/structures/pseudo/delogic_logic.py
+++ b/decompiler/structures/pseudo/delogic_logic.py
@@ -1,4 +1,5 @@
 """Implements translating pseudo instructions into delogic statements."""
+
 from __future__ import annotations
 
 from typing import Union

--- a/decompiler/structures/pseudo/expressions.py
+++ b/decompiler/structures/pseudo/expressions.py
@@ -26,6 +26,7 @@ unknown          <-  string_constant("error_message")
 constant         <-  string_constant | numeric_constant
 
 """
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/decompiler/structures/pseudo/instructions.py
+++ b/decompiler/structures/pseudo/instructions.py
@@ -1,4 +1,5 @@
 """Module modeling all pseudo code instructions."""
+
 from __future__ import annotations
 
 import logging

--- a/decompiler/structures/pseudo/logic.py
+++ b/decompiler/structures/pseudo/logic.py
@@ -1,4 +1,5 @@
 """Implements translating psuedo instructions into logic statements."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/decompiler/structures/pseudo/operations.py
+++ b/decompiler/structures/pseudo/operations.py
@@ -1,4 +1,5 @@
 """Module declaring all valid IR operations."""
+
 from __future__ import annotations
 
 import logging

--- a/decompiler/structures/pseudo/typing.py
+++ b/decompiler/structures/pseudo/typing.py
@@ -1,4 +1,5 @@
 """Module implementing the typing system for the pseudo language."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/decompiler/structures/pseudo/z3_logic.py
+++ b/decompiler/structures/pseudo/z3_logic.py
@@ -1,4 +1,5 @@
 """Implements translating psuedo instructions into logic statements."""
+
 from __future__ import annotations
 
 import logging

--- a/decompiler/structures/visitors/interfaces.py
+++ b/decompiler/structures/visitors/interfaces.py
@@ -1,4 +1,5 @@
 """Module for visitor ABCs."""
+
 from abc import ABC, abstractmethod
 from typing import Generic, TypeVar
 

--- a/decompiler/task.py
+++ b/decompiler/task.py
@@ -1,4 +1,5 @@
 """Module describing tasks to be handled by the decompiler pipleline."""
+
 from typing import Dict, List, Optional
 
 from decompiler.structures.ast.syntaxtree import AbstractSyntaxTree

--- a/decompiler/util/commandline.py
+++ b/decompiler/util/commandline.py
@@ -1,4 +1,5 @@
 """Command line interface for the decompiler."""
+
 from argparse import SUPPRESS, ArgumentParser
 from enum import Enum
 from os import isatty

--- a/decompiler/util/decoration.py
+++ b/decompiler/util/decoration.py
@@ -1,4 +1,5 @@
 """Module handling plotting and pretty printing."""
+
 from __future__ import annotations
 
 import textwrap

--- a/decompiler/util/options.py
+++ b/decompiler/util/options.py
@@ -1,4 +1,5 @@
 """File in charge of managing config and commandline options for decompilation."""
+
 import json
 import logging
 from argparse import ArgumentParser, BooleanOptionalAction, Namespace

--- a/decompiler/util/serialization/astnode_serializer.py
+++ b/decompiler/util/serialization/astnode_serializer.py
@@ -1,4 +1,5 @@
 """Module implementing the serialization of AbstractSyntaxTreeNode subclasses."""
+
 from abc import ABC
 from typing import Dict, Optional
 

--- a/decompiler/util/serialization/interface.py
+++ b/decompiler/util/serialization/interface.py
@@ -1,4 +1,5 @@
 """Module implementing the base interface for all serializers."""
+
 from abc import ABC, abstractmethod
 from typing import Dict, Generic, TypeVar
 

--- a/test_threadsafety.py
+++ b/test_threadsafety.py
@@ -1,4 +1,5 @@
 """Module testing whether dewolf is still threadsafe and z3 does not generate segmentationfaults anymore."""
+
 import faulthandler
 from concurrent.futures import ThreadPoolExecutor
 

--- a/tests/pipeline/SSA/test_out_of_ssa.py
+++ b/tests/pipeline/SSA/test_out_of_ssa.py
@@ -1,4 +1,5 @@
 """Pytest for Out of SSA."""
+
 from decompiler.pipeline.ssa.outofssatranslation import OutOfSsaTranslation
 from decompiler.structures.graphs.cfg import BasicBlockEdgeCondition
 from decompiler.structures.pseudo import Expression, Type, UnknownExpression

--- a/tests/pipeline/SSA/test_phi_dependency_graph.py
+++ b/tests/pipeline/SSA/test_phi_dependency_graph.py
@@ -1,4 +1,5 @@
 """Pytest for Dependency Graph in Out of SSA."""
+
 from typing import List
 
 import pytest

--- a/tests/pipeline/commons/test_liveness_analysis.py
+++ b/tests/pipeline/commons/test_liveness_analysis.py
@@ -1,4 +1,5 @@
 """Pytest for Liveness Analysis."""
+
 from typing import List, Tuple
 
 import pytest

--- a/tests/pipeline/controlflowanalysis/restructuring_commons/test_condition_aware_refinement.py
+++ b/tests/pipeline/controlflowanalysis/restructuring_commons/test_condition_aware_refinement.py
@@ -1,4 +1,5 @@
 """ Tests for the PatternIndependentRestructuring pipeline stage condition aware refinement."""
+
 from itertools import combinations
 from typing import List, Tuple, Union
 

--- a/tests/pipeline/dataflowanalysis/test_dead-code-elimination.py
+++ b/tests/pipeline/dataflowanalysis/test_dead-code-elimination.py
@@ -1,4 +1,5 @@
 """ Tests for the DeadCodeElimination pipeline stage"""
+
 from abc import ABC, abstractmethod
 
 import pytest

--- a/tests/pipeline/preprocessing/test-coherence.py
+++ b/tests/pipeline/preprocessing/test-coherence.py
@@ -1,4 +1,5 @@
 """Pytest for InsertingMissingDefinitions."""
+
 from typing import Dict
 
 import pytest

--- a/tests/pipeline/preprocessing/test_insert_missing_definition.py
+++ b/tests/pipeline/preprocessing/test_insert_missing_definition.py
@@ -1,4 +1,5 @@
 """Pytest for InsertingMissingDefinitions."""
+
 from typing import List
 
 import pytest

--- a/tests/pipeline/test-pipeline.py
+++ b/tests/pipeline/test-pipeline.py
@@ -1,4 +1,5 @@
 """Tests for the pipeline system."""
+
 import pytest
 from decompiler.pipeline.default import AST_STAGES, CFG_STAGES
 from decompiler.pipeline.pipeline import DecompilerPipeline

--- a/tests/structures/ast/test_syntaxforest.py
+++ b/tests/structures/ast/test_syntaxforest.py
@@ -1,4 +1,5 @@
 """ Tests for the AbstractSyntaxTree base class."""
+
 from itertools import combinations
 
 from decompiler.structures.ast.ast_comparator import ASTComparator

--- a/tests/structures/ast/test_syntaxgraph.py
+++ b/tests/structures/ast/test_syntaxgraph.py
@@ -1,4 +1,5 @@
 """ Tests for the AbstractSyntaxTree base class."""
+
 from itertools import combinations
 
 from decompiler.structures.ast.syntaxforest import AbstractSyntaxInterface

--- a/tests/structures/ast/test_syntaxtree.py
+++ b/tests/structures/ast/test_syntaxtree.py
@@ -1,4 +1,5 @@
 """ Tests for the AbstractSyntaxTree base class."""
+
 import pytest
 from decompiler.structures.ast.ast_nodes import CodeNode, SeqNode, VirtualRootNode
 from decompiler.structures.ast.syntaxtree import AbstractSyntaxTree

--- a/tests/structures/graphs/test_basic.py
+++ b/tests/structures/graphs/test_basic.py
@@ -1,4 +1,5 @@
 """Module implementing tests for the most basic node and edge implementations."""
+
 from decompiler.structures.graphs.basic import BasicEdge, BasicNode
 
 

--- a/tests/structures/graphs/test_basicblock.py
+++ b/tests/structures/graphs/test_basicblock.py
@@ -1,4 +1,5 @@
 """Module implementing tests for the BasicBlock class pseudo instruction container."""
+
 from functools import partial
 
 import pytest

--- a/tests/structures/graphs/test_classifiedgraph.py
+++ b/tests/structures/graphs/test_classifiedgraph.py
@@ -1,4 +1,5 @@
 """Module implementing tests for the ClassifiedGraph class."""
+
 from decompiler.structures.graphs.basic import BasicEdge, BasicNode
 from decompiler.structures.graphs.classifiedgraph import ClassifiedGraph, EdgeProperty
 

--- a/tests/structures/graphs/test_graph_interface.py
+++ b/tests/structures/graphs/test_graph_interface.py
@@ -1,4 +1,5 @@
 """Implementing tests for the GraphInterface."""
+
 from typing import List, Tuple
 
 import pytest

--- a/tests/structures/graphs/test_rootedgraph.py
+++ b/tests/structures/graphs/test_rootedgraph.py
@@ -1,4 +1,5 @@
 """Module implementing tests for the RootedGraph implementation."""
+
 from typing import Tuple
 
 from decompiler.structures.graphs.basic import BasicEdge, BasicNode

--- a/tests/structures/logic/test_interface_decorator.py
+++ b/tests/structures/logic/test_interface_decorator.py
@@ -26,8 +26,7 @@ class BaseCase:
 
 
 def test_classes_without_methods_can_be_wrapped():
-    class TestCase(StupidBaseCase):
-        ...
+    class TestCase(StupidBaseCase): ...
 
     a = TestCase()
     assert a
@@ -43,8 +42,7 @@ def test_classes_with_init():
 
 
 def test_classes_with_return_value():
-    class TestCase(BaseCase):
-        ...
+    class TestCase(BaseCase): ...
 
     a = TestCase(5)
     assert a._input == 12

--- a/tests/structures/pseudo/test_typing.py
+++ b/tests/structures/pseudo/test_typing.py
@@ -1,4 +1,5 @@
 """Tests for the pseudo typing functionality."""
+
 import pytest
 from decompiler.structures.pseudo.typing import CustomType, Float, Integer, Pointer, TypeParser
 

--- a/tests/structures/test_interferencegraph.py
+++ b/tests/structures/test_interferencegraph.py
@@ -1,4 +1,5 @@
 """Pytest for the Interference Graph."""
+
 from typing import List, Tuple
 
 import pytest

--- a/tests/util/test_lexicographical_bfs.py
+++ b/tests/util/test_lexicographical_bfs.py
@@ -1,4 +1,5 @@
 """Pytest for lexicographical BFS."""
+
 from decompiler.structures.interferencegraph import InterferenceGraph
 from decompiler.util.lexicographical_bfs import LexicographicalBFS
 


### PR DESCRIPTION
The Black Code Formatter was updated in the last few days (23.12.1 -> 24.1.0 -> 24.1.1) and brought some changes. See the [release notes](https://github.com/psf/black/releases).

Our checks are now failing because many files don't match the new formatting:
```
python -m black --check .

[...]

Oh no! 💥 💔 💥
107 files would be reformatted, 204 files would be left unchanged.
```

Mostly those failures consists of adding a new line after the opening command of a python file:
```
--- /opt/binaryninja/plugins/dewolf/tests/pipeline/controlflowanalysis/restructuring_commons/test_condition_aware_refinement.py     2023-08-17 14:01:07.815326+00:00
+++ /opt/binaryninja/plugins/dewolf/tests/pipeline/controlflowanalysis/restructuring_commons/test_condition_aware_refinement.py     2024-01-29 12:17:44.659690+00:00
@@ -1,6 +1,7 @@
 """ Tests for the PatternIndependentRestructuring pipeline stage condition aware refinement."""
+
 from itertools import combinations
 from typing import List, Tuple, Union

 import pytest
 from decompiler.pipeline.controlflowanalysis.restructuring import PatternIndependentRestructuring
would reformat /opt/binaryninja/plugins/dewolf/tests/pipeline/controlflowanalysis/restructuring_commons/test_condition_aware_refinement.py
```

This PR should make the formatting consistent again.