### PR TITLE
Improve expression propagation by removing redundant Phi functions

### DIFF
--- a/decompiler/pipeline/commons/expressionpropagationcommons.py
+++ b/decompiler/pipeline/commons/expressionpropagationcommons.py
@@ -85,10 +85,8 @@ class ExpressionPropagationBase(PipelineStage, ABC):
                 if not all_equal(instruction.value.operands):
                     continue
 
-                basic_block.replace_instruction(
-                    instruction,
-                    Assignment(instruction.destination, instruction.value.operands[0])
-                )
+                basic_block.remove_instruction(index)
+                basic_block.add_instruction_where_possible(Assignment(instruction.destination, instruction.value.operands[0]))
                 changes |= True
         return changes
 

--- a/decompiler/pipeline/dataflowanalysis/expressionpropagationmemory.py
+++ b/decompiler/pipeline/dataflowanalysis/expressionpropagationmemory.py
@@ -1,10 +1,7 @@
-from itertools import groupby
-from typing import Iterable
-
 from decompiler.pipeline.commons.expressionpropagationcommons import ExpressionPropagationBase
 from decompiler.structures.graphs.cfg import BasicBlock, ControlFlowGraph
 from decompiler.structures.pointers import Pointers
-from decompiler.structures.pseudo import Phi, Variable
+from decompiler.structures.pseudo import Variable
 from decompiler.structures.pseudo.instructions import Assignment, Instruction
 from decompiler.task import DecompilerTask
 
@@ -112,24 +109,3 @@ class ExpressionPropagationMemory(ExpressionPropagationBase):
                     instruction.substitute(var, definition.value.copy())
                     self._update_use_map(var, instruction)
                     self._update_block_map(old_instr, str(instruction), block, index)
-
-    def _remove_redundant_phis(self, graph: ControlFlowGraph) -> bool:
-        changes = False
-        for basic_block in graph.nodes:
-            for index, instruction in enumerate(basic_block.instructions):
-                if not isinstance(instruction, Phi):
-                    continue
-                if not all_equal(instruction.value.operands):
-                    continue
-
-                basic_block.replace_instruction(
-                    instruction,
-                    Assignment(instruction.destination, instruction.value.operands[0])
-                )
-                changes |= True
-        return changes
-
-
-def all_equal(iterable: Iterable):
-    g = groupby(iterable)
-    return next(g, True) and not next(g, False)

--- a/decompiler/pipeline/dataflowanalysis/expressionpropagationmemory.py
+++ b/decompiler/pipeline/dataflowanalysis/expressionpropagationmemory.py
@@ -27,7 +27,6 @@ class ExpressionPropagationMemory(ExpressionPropagationBase):
         """
         is_changed = super().perform(graph, iteration)
         self._propagate_postponed_aliased_definitions()
-        is_changed |= self._remove_redundant_phis(graph)
         return is_changed
 
     def _definition_can_be_propagated_into_target(self, definition: Assignment, target: Instruction):

--- a/decompiler/util/iteration_util.py
+++ b/decompiler/util/iteration_util.py
@@ -1,0 +1,8 @@
+from collections.abc import Iterable
+from itertools import groupby
+
+
+def all_equal(iterable: Iterable):
+    """See https://stackoverflow.com/a/3844832"""
+    g = groupby(iterable)
+    return next(g, True) and not next(g, False)

--- a/tests/pipeline/dataflowanalysis/test_expression_propagation.py
+++ b/tests/pipeline/dataflowanalysis/test_expression_propagation.py
@@ -829,20 +829,13 @@ def test_phi_simplifcation():
     var3 = Variable("var3", Integer.int32_t())
     arg0 = Variable("arg0", Integer.int32_t())
 
-    b0 = BasicBlock(0, [
-        Assignment(var0, Constant(42, Integer.int32_t())),
-        Branch(Condition(OperationType.less, [arg0, Constant(0, Integer.int32_t())]))
-    ])
-    b1 = BasicBlock(1, [
-        Assignment(var1, var0)
-    ])
-    b2 = BasicBlock(2, [
-        Assignment(var2, var0)
-    ])
-    b3 = BasicBlock(3, [
-        Phi(var3, [var1, var2], {b1: var1, b2: var2}),
-        ret_ins := Return([var3])
-    ])
+    b0 = BasicBlock(
+        0,
+        [Assignment(var0, Constant(42, Integer.int32_t())), Branch(Condition(OperationType.less, [arg0, Constant(0, Integer.int32_t())]))],
+    )
+    b1 = BasicBlock(1, [Assignment(var1, var0)])
+    b2 = BasicBlock(2, [Assignment(var2, var0)])
+    b3 = BasicBlock(3, [Phi(var3, [var1, var2], {b1: var1, b2: var2}), ret_ins := Return([var3])])
 
     cfg = ControlFlowGraph()
     cfg.add_node(b0)
@@ -857,6 +850,7 @@ def test_phi_simplifcation():
     _run_expression_propagation(cfg)
 
     assert ret_ins.values.operands == [Constant(42, Integer.int32_t())]
+
 
 def _generate_options(instr: int = 10, branch: int = 10, call: int = 10, assignment: int = 10) -> Options:
     options = Options()

--- a/tests/pipeline/dataflowanalysis/test_expression_propagation.py
+++ b/tests/pipeline/dataflowanalysis/test_expression_propagation.py
@@ -819,6 +819,45 @@ def test_contraction_copy():
     assert id(instr1.value) != id(instr2.value)
 
 
+def test_phi_simplifcation():
+    """
+    Test that redundant phi functions are removed, enabling better propagation.
+    """
+    var0 = Variable("var0", Integer.int32_t())
+    var1 = Variable("var1", Integer.int32_t())
+    var2 = Variable("var2", Integer.int32_t())
+    var3 = Variable("var3", Integer.int32_t())
+    arg0 = Variable("arg0", Integer.int32_t())
+
+    b0 = BasicBlock(0, [
+        Assignment(var0, Constant(42, Integer.int32_t())),
+        Branch(Condition(OperationType.less, [arg0, Constant(0, Integer.int32_t())]))
+    ])
+    b1 = BasicBlock(1, [
+        Assignment(var1, var0)
+    ])
+    b2 = BasicBlock(2, [
+        Assignment(var2, var0)
+    ])
+    b3 = BasicBlock(3, [
+        Phi(var3, [var1, var2], {b1: var1, b2: var2}),
+        ret_ins := Return([var3])
+    ])
+
+    cfg = ControlFlowGraph()
+    cfg.add_node(b0)
+    cfg.add_node(b1)
+    cfg.add_node(b2)
+    cfg.add_node(b3)
+    cfg.add_edge(TrueCase(b0, b1))
+    cfg.add_edge(FalseCase(b0, b2))
+    cfg.add_edge(UnconditionalEdge(b1, b3))
+    cfg.add_edge(UnconditionalEdge(b2, b3))
+
+    _run_expression_propagation(cfg)
+
+    assert ret_ins.values.operands == [Constant(42, Integer.int32_t())]
+
 def _generate_options(instr: int = 10, branch: int = 10, call: int = 10, assignment: int = 10) -> Options:
     options = Options()
     options.set("expression-propagation.maximum_instruction_complexity", instr)


### PR DESCRIPTION
In some cases the decompiler fails to reconstruct simple control structures, because the decompiled code contains redundant variables. These variables are caused by Phi functions, that use the same value indifferent to the control flow path taken.

This PR adds code that removes these redundant Phi functions before each expression propagation iteration, enabling more expressions to be propagated.

An example where this causes a switch to not be constructed is `test17` in [systemtest/32/3/test_condition](https://github.com/fkie-cad/dewolf/files/14208002/test_condition.zip).
