### PR TITLE
Change automatic release to not push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set git user
         uses: fregante/setup-git-user@v2
@@ -25,15 +28,12 @@ jobs:
         id: update
         run: echo "version=$(python update_for_release.py)" >> "$GITHUB_OUTPUT" # returns new version to output
 
-      - name: Commit changes
+      - name: Commit changes & push
         run: |
           git add plugin.json
           git commit -m "Update for release ${{ steps.update.outputs.version }}"
-
-      - name: Push changes and tags
-        run: |
-          git push origin HEAD
-          git push origin --tags
+          git tag "v${{ steps.update.outputs.version }}"
+          git push origin v${{ steps.update.outputs.version }}
 
       - name: Create release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
+        with: # https://github.com/actions/checkout/issues/1471
           fetch-depth: 0
           fetch-tags: true
 

--- a/plugin.json
+++ b/plugin.json
@@ -27,7 +27,6 @@
         ],
         "other": []
     },
-    "version": "0.2.0",
     "author": "fkie-cad",
     "minimumbinaryninjaversion": 4271
 }

--- a/update_for_release.py
+++ b/update_for_release.py
@@ -1,18 +1,25 @@
 import json
+import subprocess
 import time
 from pathlib import Path
 
+
+def get_patch(line: str) -> int:
+    return int(line[index + 1 :]) if (index := line.rfind(".")) != -1 else 0
+
+
 if __name__ == "__main__":
+    new_version = time.strftime("%Y-%m-%d")
+
+    process = subprocess.run(["git", "tag", "-l", f"v{new_version}*"], text=True, capture_output=True)
+    patch = max((get_patch(line) for line in process.stdout.splitlines()), default=None)
+
+    if patch is not None:
+        new_version += f".{patch + 1}"
+
     release_path = Path("plugin.json")
     with release_path.open("r") as file:
         data = json.load(file)
-
-    old_version: str = data["version"]
-    new_version = time.strftime("%Y-%m-%d")
-
-    if old_version.startswith(new_version):
-        patch = int(old_version[index + 1 :]) if (index := old_version.rfind(".")) != -1 else 0
-        new_version += f".{patch + 1}"
 
     data["version"] = new_version
 


### PR DESCRIPTION
#392 doesn't work with the branch protection rules of the repository. The github action tries to push a commit to `main`, which gets rejected. 

This PR fixes this by changing the automatic release action to not push the newly created commit to main. Instead, the commit is simply tagged and only the tag is pushed. This means that the release commit is not contained in the main branch, which I think is fine though.