### PR TITLE
Fix support for Binary Ninja 3.5 by not requiring SymbolicFunctionSymbol

### DIFF
--- a/decompiler/frontend/binaryninja/handlers/symbols.py
+++ b/decompiler/frontend/binaryninja/handlers/symbols.py
@@ -26,8 +26,12 @@ class SymbolHandler(Handler):
             SymbolType.ImportedDataSymbol: Symbol,
             SymbolType.ExternalSymbol: ImportedFunctionSymbol,
             SymbolType.LibraryFunctionSymbol: Symbol,
-            SymbolType.SymbolicFunctionSymbol: FunctionSymbol,
         }
+        # SymbolicFunctionSymbol is not available for Binary Ninja < 4
+        try:
+            self.SYMBOL_MAP[SymbolType.SymbolicFunctionSymbol] = FunctionSymbol
+        except AttributeError:
+            pass
 
     def register(self):
         """Register the handler at the parent lifter."""


### PR DESCRIPTION
Binary Ninja 4.0 introduced `SymbolType.SymbolicFunctionSymbol`, which is now used by the frontend.
This change prevents dewolf from crashing when Binary Ninja 3.5 is used.