### PR TITLE
Improve performance of expression propagation

### DIFF
--- a/decompiler/structures/graphs/basicblock.py
+++ b/decompiler/structures/graphs/basicblock.py
@@ -44,6 +44,7 @@ class BasicBlock(GraphNodeInterface):
 
     def __str__(self) -> str:
         """Return a string representation of all instructions in the basic block."""
+        return repr(self)
         return "\n".join((f"{instruction}" for instruction in self))
 
     def __repr__(self) -> str:

--- a/decompiler/structures/graphs/basicblock.py
+++ b/decompiler/structures/graphs/basicblock.py
@@ -43,9 +43,10 @@ class BasicBlock(GraphNodeInterface):
         yield from self._instructions
 
     def __str__(self) -> str:
-        """Return a string representation of all instructions in the basic block."""
+        """Return a string representation of the block"""
+        # Note: Returning a string representation of all instructions here can be pretty expensive.
+        # Because most code does not expect this, we choose to simply return the cheap repr instead.
         return repr(self)
-        return "\n".join((f"{instruction}" for instruction in self))
 
     def __repr__(self) -> str:
         """Return a debug representation of the block."""

--- a/decompiler/structures/graphs/restructuring_graph/transition_cfg.py
+++ b/decompiler/structures/graphs/restructuring_graph/transition_cfg.py
@@ -29,7 +29,7 @@ class TransitionBlock(GraphNodeInterface):
         self.ast: AbstractSyntaxTreeNode = ast
 
     def __str__(self) -> str:
-        """Return a string representation of all instructions in the basic block."""
+        """Return a string representation of the block"""
         return str(self.ast)
 
     def __repr__(self) -> str:

--- a/tests/structures/graphs/test_basicblock.py
+++ b/tests/structures/graphs/test_basicblock.py
@@ -117,7 +117,7 @@ def test_instruction_management(testblock: BasicBlock):
 
 
 def test_block_representations(testblock: BasicBlock):
-    assert str(testblock) == "\n".join(str(instruction) for instruction in testblock)
+    assert str(testblock) == "BasicBlock(0x539, len=5)"
     assert repr(testblock) == "BasicBlock(0x539, len=5)"
 
 


### PR DESCRIPTION
For some larger binaries, expression propagation can be quite slow.
One of the many reasons for this is that networkx assumes (maybe rightfully so), that calls to `__str__` of nodes are relatively cheap, compared operation of calculating if a path exists between two nodes.
However, because basicblocks create a string representation by printing every single instruction, a lot of time is spend on this instead.

This PR changes changes the implementation of `__str__` of basicblocks to simply use the cheap debu representation instead.