### PR TITLE
Improve compiler idioms performance

### DIFF
--- a/decompiler/frontend/binaryninja/frontend.py
+++ b/decompiler/frontend/binaryninja/frontend.py
@@ -39,6 +39,7 @@ class BinaryninjaFrontend(Frontend):
     def __init__(self, bv: BinaryView):
         """Create a new binaryninja view with the given path."""
         self._bv = bv if type(bv) == BinaryView else bv.getCurrentFunction().view
+        self._tagging = CompilerIdiomsTagging(self._bv)
 
     @classmethod
     def from_path(cls, path: str, options: Options):
@@ -70,8 +71,7 @@ class BinaryninjaFrontend(Frontend):
             task.function_return_type = lifter.lift(function.return_type)
             task.function_parameters = [lifter.lift(param_type) for param_type in function.type.parameters]
 
-            tagging = CompilerIdiomsTagging(self._bv, function.start, task.options)
-            tagging.run()
+            self._tagging.run(function, task.options)
 
             task.cfg = parser.parse(function)
             task.complex_types = parser.complex_types


### PR DESCRIPTION
Currently when decompiling a single function, compiler idioms will dissemble the whole binary, which takes a considerable amount of time, when the goal is to only decompile a single function with a couple of instructions.
This PR fixes this by ~instead directly taking the disassembly from binaryninja an passing it to the compiler idioms tagging~ only disassembling the file once, the same way binary ninja only loads the binary once even when decompiling multiple functions.