### PR TITLE
Fix Pipeline

### DIFF
--- a/decompiler/backend/codegenerator.py
+++ b/decompiler/backend/codegenerator.py
@@ -8,6 +8,8 @@ from decompiler.backend.codevisitor import CodeVisitor
 from decompiler.backend.variabledeclarations import GlobalDeclarationGenerator, LocalDeclarationGenerator
 from decompiler.task import DecompilerTask
 
+FAIL_MESSAGE = "Decompilation Failed!\n"
+
 
 class CodeGenerator:
     """Class in charge of emitting C-code from pseudo code."""
@@ -53,7 +55,8 @@ class CodeGenerator:
     @staticmethod
     def generate_failure_message(task: DecompilerTask):
         """Returns the message to be shown for a failed task."""
-        msg = f"Failed to decompile {task.name}"
+        msg = FAIL_MESSAGE
+        msg += f"Failed to decompile {task.name}"
         if origin := task.failure_origin:  # checks if the string is empty (should never be None when this method is called)
             msg += f" due to error during {origin}."
         return msg

--- a/decompiler/frontend/binaryninja/frontend.py
+++ b/decompiler/frontend/binaryninja/frontend.py
@@ -76,8 +76,7 @@ class BinaryninjaFrontend(Frontend):
             task.cfg = parser.parse(function)
             task.complex_types = parser.complex_types
         except Exception as e:
-            task.fail("Function lifting")
-            logging.exception(f"Failed to decompile {task.name}, error during function lifting")
+            task.fail("Function lifting", e)
 
             if task.options.getboolean("pipeline.debug", fallback=False):
                 raise e

--- a/decompiler/pipeline/pipeline.py
+++ b/decompiler/pipeline/pipeline.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from logging import debug, error, warning
+from logging import debug, warning
 from typing import List
 
 from decompiler.pipeline.controlflowanalysis.restructuring import PatternIndependentRestructuring
@@ -108,8 +108,7 @@ class DecompilerPipeline:
                 if show_all or stage.name in showed_stages:
                     self._show_stage(task, f"After {stage.name}", print_ascii, show_in_tabs)
             except Exception as e:
-                task.fail(origin=stage.name)
-                error(f"Failed to decompile {task.name}, error during stage {stage.name}: {e}")
+                task.fail(origin=stage.name, exception=e)
                 if debug_mode:
                     raise e
                 break

--- a/decompiler/pipeline/preprocessing/missing_definitions.py
+++ b/decompiler/pipeline/preprocessing/missing_definitions.py
@@ -110,11 +110,6 @@ class InsertMissingDefinitions(PipelineStage):
         self._check_ssa_label_for_all_variables()
         self.insert_missing_definitions()
 
-        import random
-
-        if random.randint(1, 100) > 80:
-            raise ValueError("Test Error")
-
     def _setup(self, cfg: ControlFlowGraph):
         """Initialize all necessary attributes."""
         self.cfg: ControlFlowGraph = cfg

--- a/decompiler/pipeline/preprocessing/missing_definitions.py
+++ b/decompiler/pipeline/preprocessing/missing_definitions.py
@@ -110,6 +110,11 @@ class InsertMissingDefinitions(PipelineStage):
         self._check_ssa_label_for_all_variables()
         self.insert_missing_definitions()
 
+        import random
+
+        if random.randint(1, 100) > 80:
+            raise ValueError("Test Error")
+
     def _setup(self, cfg: ControlFlowGraph):
         """Initialize all necessary attributes."""
         self.cfg: ControlFlowGraph = cfg

--- a/decompiler/task.py
+++ b/decompiler/task.py
@@ -1,7 +1,8 @@
 """Module describing tasks to be handled by the decompiler pipleline."""
 
 from dataclasses import dataclass, field
-from typing import List
+from logging import error
+from typing import List, Optional
 
 from decompiler.structures.ast.syntaxtree import AbstractSyntaxTree
 from decompiler.structures.graphs.cfg import ControlFlowGraph
@@ -39,12 +40,13 @@ class DecompilerTask:
     def syntax_tree(self):
         return self.ast
 
-    def fail(self, origin: str = ""):
+    def fail(self, origin: str = "", exception: Optional[Exception] = None):
         """Sets the task to be failed by setting the failure origin."""
         if self.failure_origin is not None:
             raise RuntimeError("Tried failing already failed task")
 
         self._failure_origin = origin
+        error(f"Failed to decompile {self.name}, error during stage {origin}: {exception}")
 
     @property
     def failed(self) -> bool:

--- a/tests/test_sample_binaries.py
+++ b/tests/test_sample_binaries.py
@@ -2,13 +2,14 @@ import re
 import subprocess
 
 import pytest
+from decompiler.backend.codegenerator import FAIL_MESSAGE
 
 
 def test_sample(test_cases):
     """Test the decompiler with the given test case."""
     sample, function_name = test_cases
     output = subprocess.run(("python", "decompile.py", sample, function_name), check=True, capture_output=True).stdout.decode("utf-8")
-    assert "Failed to decompile due to error during " not in output
+    assert FAIL_MESSAGE not in output
 
 
 def test_globals():


### PR DESCRIPTION
Currently, the pipeline considers the output string to check whether a test crashes. But these strings are different.