### PR TITLE
Use capstone for ARM support, fix multiple crashes

### DIFF
--- a/decompiler/backend/cexpressiongenerator.py
+++ b/decompiler/backend/cexpressiongenerator.py
@@ -242,6 +242,11 @@ class CExpressionGenerator(DataflowObjectVisitorInterface):
                     val = "".join("\\x{:02x}".format(x) for x in expr.value)
                     return f'"{val}"' if len(val) <= MAX_GLOBAL_INIT_LENGTH else f'"{val[:MAX_GLOBAL_INIT_LENGTH]}..."'
         if isinstance(expr.type, ArrayType):
+            # Handle case where expr.value might be an int instead of iterable
+            if not hasattr(expr.value, '__iter__') or isinstance(expr.value, (int, str)):
+                # If value is not iterable (or is a string/int), just format it directly
+                return str(expr.value)
+            
             match expr.type.type:
                 case CustomType(text="wchar16") | CustomType(text="wchar32"):
                     val = "".join(expr.value).translate(self.ESCAPE_TABLE)

--- a/decompiler/frontend/binaryninja/tagging.py
+++ b/decompiler/frontend/binaryninja/tagging.py
@@ -2,7 +2,7 @@ import logging
 
 import binaryninja.function
 from binaryninja import BinaryView
-from compiler_idioms.disassembly.smda_disassembly import SMDADisassembly
+from compiler_idioms.disassembly.capstone_disassembly import CapstoneDisassembly
 from compiler_idioms.matcher import Matcher
 from decompiler.util.options import Options
 
@@ -15,7 +15,7 @@ class CompilerIdiomsTagging:
 
     def __init__(self, binary_view: BinaryView):
         self._bv = binary_view
-        self._disassembly = SMDADisassembly(self._bv.file.filename)
+        self._disassembly = CapstoneDisassembly(self._bv.file.filename)
         self._matcher = Matcher()
 
     def run(self, function: binaryninja.function.Function, options: Options):
@@ -29,7 +29,7 @@ class CompilerIdiomsTagging:
         if not enabled:
             return
         try:
-            instructions = self._disassembly.get_smda_function_at(function.start)
+            instructions = self._disassembly.get_function_at(function.start)
             matches = self._matcher._match_single_function(instructions)
         except Exception as e:
             if debug_submodules:

--- a/decompiler/pipeline/controlflowanalysis/restructuring.py
+++ b/decompiler/pipeline/controlflowanalysis/restructuring.py
@@ -84,7 +84,11 @@ class PatternIndependentRestructuring(PipelineStage):
                 self.t_cfg.refresh_edge_properties()
                 loop_heads = self._get_loop_heads()
 
-        AcyclicRegionRestructurer(self.t_cfg, self.asforest, self.options).restructure()
+        try:
+            AcyclicRegionRestructurer(self.t_cfg, self.asforest, self.options).restructure()
+        except RuntimeError as e:
+            logging.error(f"Failed to restructure acyclic regions: {e}")
+            raise
         self._fulfill_switch_options()
 
     def _restructure_empty_cfg(self):

--- a/decompiler/pipeline/dataflowanalysis/common_subexpression_elimination.py
+++ b/decompiler/pipeline/dataflowanalysis/common_subexpression_elimination.py
@@ -251,7 +251,11 @@ class DefinitionGenerator:
         usage_blocks: Set[BasicBlock] = {instruction.block for instruction in self._usages[expression]}
         candidate: BasicBlock = next(iter(usage_blocks))
         while not self._is_common_dominator(candidate, usage_blocks) or self._is_invalid_dominator(candidate, expression):
-            candidate = self._dominator_tree.get_predecessors(candidate)[0]
+            predecessors = self._dominator_tree.get_predecessors(candidate)
+            if not predecessors:
+                # No dominating block found - this can happen with unusual control flow
+                raise StopIteration(f"No common dominator found for expression {expression}")
+            candidate = predecessors[0]
         return candidate, self._find_insertion_index(candidate, self._usages[expression].keys())
 
     def _is_common_dominator(self, candidate: BasicBlock, basic_blocks: Set[BasicBlock]) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,23 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dewolf"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "capstone",
+    "networkx != 2.8.4",
+    "pydot",
+    "pygments",
+    "z3-solver>=4.12.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["decompiler*"]
+
 [tool.black]
 line-length = 140
 target-version = ['py310']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 git+https://github.com/fkie-cad/dewolf-logic.git#egg=delogic
 git+https://github.com/fkie-cad/dewolf-idioms.git
+capstone
 black
 isort
 networkx != 2.8.4
@@ -7,4 +8,4 @@ pydot
 pygments
 pytest !=5.3.4
 pytest-xdist
-z3-solver == 4.8.10
+z3-solver>=4.12.0


### PR DESCRIPTION
After enabling ARM support in dewolf-idioms (and the capstone changes here), I stumbled over several crashes when analyzing libauthinstall.dylib and libimage4.dylib (arm64 armv8) extracted from the aarch64 dyld shared cache.

Fixed multiple crashes and infinite loops:

-  Expression generation: Added type guards to prevent crashes when array values are non-iterable or primitives
-  Tagging: Migrated from SMDA to Capstone disassembly backend for better compatibility
-  Restructuring: Added maximum iteration limits (10× graph size) to detect and fail gracefully on infinite loops, with clearer error messages for unsupported control flow patterns
-  CSE: Added safety check for empty predecessor lists during dominator tree traversal to prevent index errors

For the sake of context and future reference, these were the binaries:

- [libimage4.dylib.zip](https://github.com/user-attachments/files/23143332/libimage4.dylib.zip)
- [libauthinstall.dylib.zip](https://github.com/user-attachments/files/23143333/libauthinstall.dylib.zip)

On a personal note, _which may very well be placebo,_ using capstone made the plugin siginificantly more snappy and responsive with way lower decompilation times.